### PR TITLE
Don't expose MongoDB port in self-host compose.yml

### DIFF
--- a/self-host.docker-compose.yml
+++ b/self-host.docker-compose.yml
@@ -19,5 +19,3 @@ services:
   mongo:
     image: mongo:6
     restart: always
-    ports:
-      - '27017:27017'


### PR DESCRIPTION
Since the backend server can only use the default credentials at the moment, it would be best to not expose MongoDB in case the user has a misconfigured firewall.