### PR TITLE
Mount /app/dist/assets in persistent Docker volume instead of hardcoded host dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:18-bullseye-slim
 WORKDIR /app
 VOLUME [ "/app/db" ]
 VOLUME [ "/app/assets" ]
+VOLUME [ "/app/dist/assets" ]
 
 RUN npm install pnpm -g
 

--- a/self-host.docker-compose.yml
+++ b/self-host.docker-compose.yml
@@ -13,8 +13,6 @@ services:
       - INITIAL_USER=admin
       - INITIAL_PASSWORD=password
       - JWT_SECRET=self-hosting
-    volumes:
-      - /dist/assets:/app/dist/assets
     
   mongo:
     image: mongo:6


### PR DESCRIPTION
Fix for issue https://github.com/luminai-companion/agn-ai/issues/79