### PR TITLE
Add preset duplication

### DIFF
--- a/web/pages/GenerationPresets/PresetList.tsx
+++ b/web/pages/GenerationPresets/PresetList.tsx
@@ -1,5 +1,5 @@
 import { A, useNavigate } from '@solidjs/router'
-import { Edit, Plus, Trash } from 'lucide-solid'
+import { Copy, Edit, Plus, Trash } from 'lucide-solid'
 import { Component, createEffect, createSignal, For, Show } from 'solid-js'
 import Button from '../../shared/Button'
 import { ConfirmModal } from '../../shared/Modal'
@@ -57,6 +57,14 @@ const PresetList: Component = () => {
                 class="icon-button"
               >
                 <Trash />
+              </Button>
+              <Button
+                schema="clear"
+                size="sm"
+                onClick={() => nav(`/presets/new?fromPresetId=${preset._id}`)}
+                class="icon-button"
+              >
+                <Copy />
               </Button>
             </div>
           )}

--- a/web/pages/GenerationPresets/PresetList.tsx
+++ b/web/pages/GenerationPresets/PresetList.tsx
@@ -46,10 +46,18 @@ const PresetList: Component = () => {
             <div class="flex w-1/2 items-center gap-2">
               <A
                 href={`/presets/${preset._id}`}
-                class="flex h-12 w-full gap-4 rounded-xl bg-[var(--bg-800)] hover:bg-[var(--bg-600)]"
+                class="flex h-12 w-full gap-2 rounded-xl bg-[var(--bg-800)] hover:bg-[var(--bg-600)]"
               >
                 <div class="ml-4 flex w-full items-center">{preset.name}</div>
               </A>
+              <Button
+                schema="clear"
+                size="sm"
+                onClick={() => nav(`/presets/new?preset=${preset._id}`)}
+                class="icon-button"
+              >
+                <Copy />
+              </Button>
               <Button
                 schema="clear"
                 size="sm"
@@ -57,14 +65,6 @@ const PresetList: Component = () => {
                 class="icon-button"
               >
                 <Trash />
-              </Button>
-              <Button
-                schema="clear"
-                size="sm"
-                onClick={() => nav(`/presets/new?fromPresetId=${preset._id}`)}
-                class="icon-button"
-              >
-                <Copy />
               </Button>
             </div>
           )}

--- a/web/pages/GenerationPresets/index.tsx
+++ b/web/pages/GenerationPresets/index.tsx
@@ -37,9 +37,8 @@ export const GenerationPresetsPage: Component = () => {
     if (params.id === 'new') {
       setEditing()
       await Promise.resolve()
-      let preset = emptyPreset
-      const templatePreset = state.presets.find((p) => p._id === queryParams.fromPresetId)
-      if (templatePreset) preset = { ...templatePreset, name: `${templatePreset.name} (duplicate)` }
+      const template = state.presets.find((p) => p._id === queryParams.preset)
+      const preset = template ? { ...template } : { ...emptyPreset }
       setEditing((_) => ({ ...preset, _id: '', kind: 'gen-setting', userId: '' }))
       return
     }

--- a/web/pages/GenerationPresets/index.tsx
+++ b/web/pages/GenerationPresets/index.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from '@solidjs/router'
+import { useNavigate, useParams, useSearchParams } from '@solidjs/router'
 import { Edit, Plus, Save, X } from 'lucide-solid'
 import { Component, createEffect, createSignal, Show } from 'solid-js'
 import { defaultPresets, presetValidator } from '../../../common/presets'
@@ -16,6 +16,7 @@ export const GenerationPresetsPage: Component = () => {
   let ref: any
 
   const params = useParams()
+  const [queryParams] = useSearchParams()
 
   const nav = useNavigate()
   const [edit, setEdit] = createSignal(false)
@@ -36,7 +37,10 @@ export const GenerationPresetsPage: Component = () => {
     if (params.id === 'new') {
       setEditing()
       await Promise.resolve()
-      setEditing((_) => ({ _id: '', ...emptyPreset, kind: 'gen-setting', userId: '' }))
+      let preset = emptyPreset
+      const templatePreset = state.presets.find((p) => p._id === queryParams.fromPresetId)
+      if (templatePreset) preset = { ...templatePreset, name: `${templatePreset.name} (duplicate)` }
+      setEditing((_) => ({ ...preset, _id: '', kind: 'gen-setting', userId: '' }))
       return
     }
 

--- a/web/shared/GenerationSettings.tsx
+++ b/web/shared/GenerationSettings.tsx
@@ -149,12 +149,12 @@ const PromptSettings: Component<Props> = (props) => {
           <>
             How the character definitions are sent to OpenAI. Placeholders:{' '}
             <code>{'{{char}}'}</code> <code>{'{{user}}'}</code> <code>{'{{personality}}'}</code>{' '}
-            <code>{'{{memory}}'}</code> <code>{'{{example_dialogue}}'}</code>. If{' '}
-            <code>{'{{example_dialogue}}'}</code> is not present then example dialogues will be sent
-            as conversation.
+            <code>{'{{memory}}'}</code> <code>{'{{scenario}}'}</code>{' '}
+            <code>{'{{example_dialogue}}'}</code>. If <code>{'{{example_dialogue}}'}</code> is not
+            present then example dialogues will be sent as conversation.
           </>
         }
-        placeholder="Be sure to include "
+        placeholder="Be sure to include the placeholders above"
         isMultiline
         value={props.inherit?.gaslight ?? defaultPresets.openai.gaslight}
         disabled={props.disabled}


### PR DESCRIPTION
This PR allows users to click a button beside an existing preset on the Generation Presets page to begin editing a new preset initialized from the existing one. This can be useful when a user would like to create a few variants of the same preset, such as high vs low temperature, NSFW vs SFW gaslight, and so forth.

Also addresses some small issues with incomplete helper text for the Gaslight section when editing a preset.

![image](https://user-images.githubusercontent.com/92774204/227703935-0735b325-5f82-4e66-a9a9-86d63907a5ff.png)
![image](https://user-images.githubusercontent.com/92774204/227704031-ae54caf0-a6fb-47ed-bec7-894189799349.png)

