### PR TITLE
Fix `maxContextLength` not being passed to openai adapter

### DIFF
--- a/common/presets.ts
+++ b/common/presets.ts
@@ -181,6 +181,7 @@ export const serviceGenMap: Record<Exclude<ChatAdapter, 'default'>, GenMap> = {
   },
   openai: {
     maxTokens: 'max_tokens',
+    maxContextLength: 'maxContextLength',
     repetitionPenalty: '',
     repetitionPenaltyRange: '',
     repetitionPenaltySlope: '',


### PR DESCRIPTION
This PR partially addresses #93 but may not resolve the problem for other adapters. A preset's `maxContextLength` was being incorrectly stripped from the settings object used by the openai adapter to figure out its token budget, causing it to fall back to the `basic` preset value of 2048.  ~~Might be happening for other adapters too, but maybe obfuscated by most other services not supporting >2048 context to begin with.~~

~~Better solution might be to special-case this value rather than add it to every serviceGenMap since it seems like it's the kind of thing that 1) every service requires and 2) doesn't even need to be sent to the downstream service at all since it's used to build the prompt within Agnai.~~

Edit: Following scueick's clarification I think this probably doesn't happen on any other adapters and is specific to Turbo because of how it has to transform the prompt built by the client into the weird format expected by OAI's chat endpoint.