### PR TITLE
Fix timestamps on imported chat messages for localStorage persistence

### DIFF
--- a/web/store/data/chats.ts
+++ b/web/store/data/chats.ts
@@ -79,15 +79,16 @@ export async function importChat(characterId: string, props: ImportChat) {
     overrides: { ...char.persona },
   })
 
-  const messages: AppSchema.ChatMessage[] = props.messages.map((msg) => ({
+  const start = Date.now()
+  const messages: AppSchema.ChatMessage[] = props.messages.map((msg, i) => ({
     _id: v4(),
     chatId: chat._id,
     kind: 'chat-message',
     msg: msg.msg,
     characterId: msg.characterId ? char._id : undefined,
     userId: msg.userId ? local.ID : undefined,
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
+    createdAt: new Date(start + i).toISOString(),
+    updatedAt: new Date(start + i).toISOString(),
   }))
 
   local.saveChats(local.loadItem('chats').concat(chat))


### PR DESCRIPTION
Follow-up to c675c27370896753cb73c253c8ddc94804134aae, resolves #97 on localstorage persistence mode for guest users