### PR TITLE
Show the chat name in the chat details

### DIFF
--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -138,6 +138,12 @@ const ChatDetail: Component = () => {
               </Show>
             </div>
 
+            <div class="flex flex-row items-center justify-between gap-4 text-sm">
+              <Show when={chats.chat?.name}>
+                {chats.chat?.name}
+              </Show>
+            </div>
+
             <div class="flex flex-row gap-3">
               <div class="hidden items-center text-xs italic text-[var(--text-500)] sm:flex">
                 {adapter()}

--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -135,12 +135,11 @@ const ChatDetail: Component = () => {
                   <ChevronLeft />
                 </A>
                 {chats.char?.name}
-              </Show>
-            </div>
-
-            <div class="flex flex-row items-center justify-between gap-4 text-sm">
-              <Show when={chats.chat?.name}>
-                {chats.chat?.name}
+                <Show when={chats.chat?.name}>
+                  <div class="flex flex-row items-center justify-between gap-4 text-sm">
+                    {chats.chat?.name}
+                  </div>
+                </Show>
               </Show>
             </div>
 


### PR DESCRIPTION
It's useful to know which chat you're on.

![image](https://user-images.githubusercontent.com/34192666/228249044-c357392f-f10b-4057-bde7-e701e381f96c.png)

A simple first PR, but I have to start somewhere! I don't have lots of UI / front end experience (I'm more on the back-end side) so feel free to make me work if I missed something!

Also I needed to change this in `package.json`. I can make a separate PR.

This, because pnpx is deprecated:
```
    "test": "pnpx mocha \"tests/**.spec.js\"",
    "test": "pnpm dlx mocha \"tests/**.spec.js\"",
```