### PR TITLE
fix: visually separate paragraphs with empty line

### DIFF
--- a/web/pages/Chat/components/Message.css
+++ b/web/pages/Chat/components/Message.css
@@ -1,3 +1,7 @@
+.rendered-markdown p:not(:last-child) {
+  margin-bottom: 1em; /* ensure <p> els are visually separated by empty line */
+}
+
 /*!
  * three-dots - v0.3.2
  * CSS loading animations made with single element

--- a/web/pages/Chat/components/Message.tsx
+++ b/web/pages/Chat/components/Message.tsx
@@ -9,6 +9,9 @@ import { chatStore, userStore } from '../../../store'
 import { MsgState, msgStore } from '../../../store'
 
 const showdownConverter = new showdown.Converter()
+// Ensure single newlines are turned into <br> instead of left as plaintext
+// newlines and hence not rendered
+showdownConverter.setOption('simpleLineBreaks', true)
 
 type MessageProps = {
   msg: SplitMessage
@@ -207,6 +210,7 @@ const SingleMessage: Component<
         <div class="break-words opacity-75">
           <Show when={!edit()}>
             <div
+              class="rendered-markdown"
               data-bot-message={isBot()}
               data-user-message={isUser()}
               innerHTML={showdownConverter.makeHtml(
@@ -236,9 +240,6 @@ function parseMessage(msg: string, char: AppSchema.Character, profile: AppSchema
     .replace(BOT_REPLACE, char.name)
     .replace(SELF_REPLACE, profile?.handle || 'You')
     .replace(/(<|>)/g, '*')
-    .split('\n')
-    .filter((v) => !!v)
-    .join('\n\n')
 }
 
 export type SplitMessage = AppSchema.ChatMessage & { split?: boolean }


### PR DESCRIPTION
closes #101

## Example

### Raw text

![1680022993](https://user-images.githubusercontent.com/128472336/228319918-49de7412-4540-4e5c-a916-ab047f43d745.png)

### Before

(NOTE: this PR defines "text blocks" as sections of a string separated by one or more newline characters.)
No matter how many linebreaks separate two text blocks in the message content, the text blocks were separated by a new line but no empty line.

![1680022971](https://user-images.githubusercontent.com/128472336/228320003-ba17e2ce-160d-4dc5-9c15-432b24f3e2d6.png)

### After

- If a single linebreak separates two text blocks, they are rendered as being separated by a new line but no empty line, as before
- If two *or more* linebreaks separate two text blocks, they are rendered as being separated by a single empty line

![1680023000](https://user-images.githubusercontent.com/128472336/228320130-5a92c012-ee9f-4718-bd46-d6a42d965867.png)

## Comments

### Previous code strategy

All occurrences of "one or more" newline characters were replaced with two newline characters, causing the markdown renderer to simply wrap all text blocks inside `<p>` elements. No styling was applied, so the `<p>` elements were not visually separated by empty lines.

### New code strategy

- Message content newline characters are now left as is, and we set the option "simpleLineBreaks" to `true` in the markdown renderer library (showdownjs). This option causes single newline characters to be rendered as `<br>` elements. Two or more newlines cause text blocks to be wrapped inside `<p>` elements.
- A CSS property is applied in order for `<p>` elements to be visually separated by an empty line.

