### PR TITLE
Include the default presets in the presets page

### DIFF
--- a/web/pages/Chat/ChatGenSettings.tsx
+++ b/web/pages/Chat/ChatGenSettings.tsx
@@ -83,7 +83,7 @@ export const ChatGenSettingsModal: Component<{
       <div class="text-sm">
         <div class="mb-2 flex items-center gap-4">
           <div>Use Preset</div>
-          <div class="mb-4">
+          <div>
             <Toggle
               fieldName={'usePreset'}
               onChange={(value) => setUsePreset(value)}

--- a/web/pages/GenerationPresets/PresetList.tsx
+++ b/web/pages/GenerationPresets/PresetList.tsx
@@ -1,14 +1,20 @@
 import { A, useNavigate } from '@solidjs/router'
-import { Copy, Edit, Plus, Trash } from 'lucide-solid'
-import { Component, createEffect, createSignal, For, onMount, Show } from 'solid-js'
+import { Copy, Plus, Trash } from 'lucide-solid'
+import { Component, createSignal, For, onMount } from 'solid-js'
 import Button from '../../shared/Button'
 import { ConfirmModal } from '../../shared/Modal'
 import PageHeader from '../../shared/PageHeader'
+import { defaultPresets } from '../../../common/presets'
 import { presetStore } from '../../store'
 
 const PresetList: Component = () => {
   const nav = useNavigate()
   const state = presetStore()
+  const defaults = Object.entries(defaultPresets).map(([name, cfg]) => ({
+    name,
+    label: `Default: ${cfg.name}`,
+    cfg,
+  }))
   const [deleting, setDeleting] = createSignal<string>()
 
   const deletePreset = () => {
@@ -25,7 +31,7 @@ const PresetList: Component = () => {
 
   return (
     <>
-      <PageHeader title="Generation Presets" subtitle="Your personal generation presets" />
+      <PageHeader title="Generation Presets" subtitle="generation settings presets" />
       <div class="mb-4 flex w-full justify-end">
         <A href="/presets/new">
           <Button>
@@ -34,15 +40,6 @@ const PresetList: Component = () => {
           </Button>
         </A>
       </div>
-      <Show when={!state.presets.length}>
-        <div class="flex w-full justify-center">
-          You have no personalised presets saved. Create a{' '}
-          <Button class="mx-2" size="sm" onClick={() => nav('/presets/new')}>
-            New Preset
-          </Button>
-          to get started.
-        </div>
-      </Show>
 
       <div class="flex flex-col items-center gap-2">
         <For each={state.presets}>
@@ -69,6 +66,27 @@ const PresetList: Component = () => {
                 class="icon-button"
               >
                 <Trash />
+              </Button>
+            </div>
+          )}
+        </For>
+
+        <For each={defaults}>
+          {(preset) => (
+            <div class="flex w-full items-center gap-2">
+              <A
+                href={`/presets/default?preset=${preset.name}`}
+                class="flex h-12 w-full gap-2 rounded-xl bg-[var(--bg-800)] hover:bg-[var(--bg-600)]"
+              >
+                <div class="ml-4 flex w-full items-center">{preset.label}</div>
+              </A>
+              <Button
+                schema="clear"
+                size="sm"
+                onClick={() => nav(`/presets/new?preset=${preset.name}`)}
+                class="icon-button"
+              >
+                <Copy />
               </Button>
             </div>
           )}

--- a/web/pages/GenerationPresets/index.tsx
+++ b/web/pages/GenerationPresets/index.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useParams, useSearchParams } from '@solidjs/router'
 import { Edit, Plus, Save, X } from 'lucide-solid'
 import { Component, createEffect, createSignal, Show } from 'solid-js'
-import { defaultPresets, presetValidator } from '../../../common/presets'
+import { defaultPresets, isDefaultPreset, presetValidator } from '../../../common/presets'
 import { AppSchema } from '../../../srv/db/schema'
 import Button from '../../shared/Button'
 import Select, { Option } from '../../shared/Select'
@@ -16,7 +16,7 @@ export const GenerationPresetsPage: Component = () => {
   let ref: any
 
   const params = useParams()
-  const [queryParams] = useSearchParams()
+  const [query] = useSearchParams()
 
   const nav = useNavigate()
   const [edit, setEdit] = createSignal(false)
@@ -37,9 +37,11 @@ export const GenerationPresetsPage: Component = () => {
     if (params.id === 'new') {
       setEditing()
       await Promise.resolve()
-      const template = state.presets.find((p) => p._id === queryParams.preset)
+      const template = isDefaultPreset(query.preset)
+        ? defaultPresets[query.preset]
+        : state.presets.find((p) => p._id === query.preset)
       const preset = template ? { ...template } : { ...emptyPreset }
-      setEditing((_) => ({ ...preset, _id: '', kind: 'gen-setting', userId: '' }))
+      setEditing({ ...emptyPreset, ...preset, _id: '', kind: 'gen-setting', userId: '' })
       return
     }
 
@@ -88,7 +90,7 @@ export const GenerationPresetsPage: Component = () => {
 
   return (
     <>
-      <PageHeader title="Generation Presets" subtitle="Your personal generation presets" />
+      <PageHeader title="Generation Presets" subtitle="generation settings presets" />
       <div class="flex flex-col gap-2">
         <div class="flex flex-row justify-between"></div>
         <div class="flex flex-col gap-4 p-2">
@@ -120,11 +122,13 @@ export const GenerationPresetsPage: Component = () => {
                 />
                 <GenerationSettings showAll={params.id === 'new'} inherit={editing()} />
               </div>
-              <div class="flex flex-row justify-end">
-                <Button type="submit" disabled={state.saving}>
-                  <Save /> Save
-                </Button>
-              </div>
+              <Show when={editing()?.userId !== 'SYSTEM'}>
+                <div class="flex flex-row justify-end">
+                  <Button type="submit" disabled={state.saving}>
+                    <Save /> Save
+                  </Button>
+                </div>
+              </Show>
             </form>
           </Show>
         </div>

--- a/web/pages/GenerationPresets/index.tsx
+++ b/web/pages/GenerationPresets/index.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams, useSearchParams } from '@solidjs/router'
+import { A, useNavigate, useParams, useSearchParams } from '@solidjs/router'
 import { Edit, Plus, Save, X } from 'lucide-solid'
 import { Component, createEffect, createSignal, Show } from 'solid-js'
 import { defaultPresets, isDefaultPreset, presetValidator } from '../../../common/presets'
@@ -42,6 +42,18 @@ export const GenerationPresetsPage: Component = () => {
         : state.presets.find((p) => p._id === query.preset)
       const preset = template ? { ...template } : { ...emptyPreset }
       setEditing({ ...emptyPreset, ...preset, _id: '', kind: 'gen-setting', userId: '' })
+      return
+    } else if (params.id === 'default') {
+      setEditing()
+      await Promise.resolve()
+      if (!isDefaultPreset(query.preset)) return
+      setEditing({
+        ...emptyPreset,
+        ...defaultPresets[query.preset],
+        _id: '',
+        kind: 'gen-setting',
+        userId: 'SYSTEM',
+      })
       return
     }
 
@@ -92,7 +104,15 @@ export const GenerationPresetsPage: Component = () => {
     <>
       <PageHeader title="Generation Presets" subtitle="Generation presets" />
       <div class="flex flex-col gap-2">
-        <div class="flex flex-row justify-between"></div>
+        <Show when={params.id === 'default'}>
+          <div class="font-bold">
+            This is a default preset and cannot be saved.{' '}
+            <A class="link" href={`/presets/new?preset=${query.preset}`}>
+              Click here
+            </A>{' '}
+            if you'd like to create a copy of this preset.
+          </div>
+        </Show>
         <div class="flex flex-col gap-4 p-2">
           <Show when={editing()}>
             <form ref={ref} onSubmit={onSave}>

--- a/web/pages/GenerationPresets/index.tsx
+++ b/web/pages/GenerationPresets/index.tsx
@@ -90,7 +90,7 @@ export const GenerationPresetsPage: Component = () => {
 
   return (
     <>
-      <PageHeader title="Generation Presets" subtitle="generation settings presets" />
+      <PageHeader title="Generation Presets" subtitle="Generation presets" />
       <div class="flex flex-col gap-2">
         <div class="flex flex-row justify-between"></div>
         <div class="flex flex-col gap-4 p-2">


### PR DESCRIPTION
This commit is not usable as-is, but rather it shows a suggestion of how presets could be shown. Hopefully, it can be used as a starting point to save you guys some time, or if you're willing to give some guidance I can continue to work on this as I learn the framework.

## Generation Presets

This page now includes all presets, the user's and the default ones.

![image](https://user-images.githubusercontent.com/34192666/228339506-448c6ce9-82ad-45f7-9327-bc72d51b82b1.png)

What's missing:

- Because the user presets take longer to load than the default ones, the loading looks weird. It should show a loading until the user presets are loaded
- The duplicate button was not implemented for defaults
- It might make sense to reverse the delete and copy buttons

## Preset

I simply changed the "Id" field for the default preset name, and hide the Save button.

What's missing:

- Disable all fields
- Clean how I implemented it

## Settings / Presets

I just added a link to send the user to the presets page if they want to know what's what.

## Next steps

- I think we should refactor things a little bit, so we use GenSettings instead of UserGenPreset everywhere, with a "readonly" field or something like that. So there wouldn't be logic scattered everywhere to deal with default presets differently.
- Understand whether you agree with this or not, and if you have some changes in mind to suggest, what are they.
- Add a new "description" field to both the user gen settings and the default presets to make it easier to understand what they do (even for your own presets).
- Finish the tasks from the notes before.

So, what do you think? Is this something you'd like to review and take over later, should I drop it, or would you allow me making a more complicated PR and refactor the presets? Keep in mind, I have to learn parcel and solid, so I might not have the expected code right :)