### PR TITLE
Fix package.json for windows (test, start:debug:win, start:public:win)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "start": "concurrently -c auto -n web,api,tsc \"parcel web/index.html --no-cache\" \"npm run server:watch\" \"npm run build:server:watch\"",
     "start:debug": "LOG_LEVEL=debug concurrently -c auto -n web,api,tsc \"parcel web/index.html --no-cache\" \"npm run server:watch\" \"npm run build:server:watch\"",
     "start:public": "concurrently -c auto -n web,api,lt \"parcel watch web/index.html\" \"npm run server:watch\" \"npx lt --port 3001\"",
-    "start:public:win": "concurrently -c auto -n web,api,lt \"parcel watch web/index.html\" \"npm run server:watch\" \"npx lt --port 3001\"",
+    "start:public:win": "concurrently -c auto -n web,api,lt \"parcel watch web/index.html\" \"npm run server:watch\" \"npx lt --local-host 127.0.0.1 --port 3001\"",
     "start:win": "concurrently -c auto -n web,api,tsc \"parcel web/index.html\" \"npm run server:watch\" \"npm run build:server:watch\"",
-    "start:debug:win": "set LOG_LEVEL debug && concurrently -c auto -n web,api,tsc \"parcel web/index.html\" \"npm run server:watch\" \"npm run build:server:watch\"",
-    "test": "pnpx mocha \"tests/**.spec.js\"",
+    "start:debug:win": "set LOG_LEVEL=debug && concurrently -c auto -n web,api,tsc \"parcel web/index.html --no-cache\" \"npm run server:watch\" \"npm run build:server:watch\"",
+    "test": "mocha \"tests/**.spec.js\"",
     "typecheck": "tsc -p tsconfig.json",
     "up": "docker compose -p agnai up -d"
   },


### PR DESCRIPTION
I had trouble getting started, here's what I needed to change to get it to work.

- localtunnel didn't work (like other people) using localhost. When I add --local-host 127.0.0.1 it works fine. I can remove this change if you want.
- pnpx is deprecated, and simply running mocha works.
- set LOG_LEVEL=debug ... crashed on Windows.
- Without --no-cache, I needed to rebuild every time I changed something in start:debug:win (it was there in start:debug)