### PR TITLE
add onto chat ui changes

### DIFF
--- a/srv/api/chat/message.ts
+++ b/srv/api/chat/message.ts
@@ -178,7 +178,7 @@ export const generateMessageV2 = handle(async ({ userId, body, socketId, params,
       sendMany(members, { type: 'message-created', msg, chatId, adapter })
     }
   } else if (body.kind === 'continue') {
-    await store.msgs.editMessage(body.continuing._id, generated, adapter)
+    await store.msgs.editMessage(body.continuing._id, responseText, adapter)
     sendMany(members, {
       type: 'message-retry',
       chatId,

--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -32,6 +32,7 @@ import UISettings from '../Settings/UISettings'
 import { devCycleAvatarSettings, isDevCommand } from './dev-util'
 import ChatOptions, { ChatModal } from './ChatOptions'
 import MemberModal from './MemberModal'
+import { AppSchema } from '../../../srv/db/schema'
 
 const EDITING_KEY = 'chat-detail-settings'
 
@@ -232,9 +233,13 @@ const ChatDetail: Component = () => {
                   )}
                 </For>
                 <Show when={msgs.waiting}>
-                  <div class="mt-3 flex justify-center">
-                    <div class="dot-flashing bg-[var(--hl-700)]"></div>
-                  </div>
+                  <Message
+                    msg={emptyMsg(chats.char?._id!, msgs.partial!)}
+                    char={chats.char!}
+                    chat={chats.chat!}
+                    onRemove={() => {}}
+                    editing={editing()}
+                  />
                 </Show>
               </div>
               <InfiniteScroll />
@@ -407,4 +412,15 @@ function getHeaderBg(mode: UI['mode']) {
     background: `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, 0.7)`,
   }
   return styles
+}
+function emptyMsg(characterId: string, message: string): AppSchema.ChatMessage {
+  return {
+    kind: 'chat-message',
+    _id: '',
+    chatId: '',
+    characterId,
+    msg: message,
+    updatedAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+  }
 }

--- a/web/pages/Chat/components/InputBar.tsx
+++ b/web/pages/Chat/components/InputBar.tsx
@@ -41,6 +41,11 @@ const InputBar: Component<{
     })
   }
 
+  const more = () => {
+    props.more(state.lastMsg.msg)
+    setMenu(false)
+  }
+
   return (
     <div class="flex items-center justify-center max-sm:pb-2">
       <Show when={user.ui.input === 'single'}>
@@ -80,12 +85,7 @@ const InputBar: Component<{
         <DropMenu show={menu()} close={() => setMenu(false)} vert="up" horz="left">
           <div class="w-48 p-2">
             <Show when={!!state.lastMsg?.characterId && props.chat.userId === user.user?._id}>
-              <Button
-                schema="secondary"
-                class="w-full"
-                onClick={() => props.more(state.lastMsg.msg)}
-                alignLeft
-              >
+              <Button schema="secondary" class="w-full" onClick={more} alignLeft>
                 <PlusCircle size={18} /> Generate More
               </Button>
             </Show>

--- a/web/pages/Chat/components/Message.tsx
+++ b/web/pages/Chat/components/Message.tsx
@@ -162,12 +162,6 @@ const SingleMessage: Component<
             >
               {new Date(props.msg.createdAt).toLocaleString()}
             </span>
-            <Show when={props.msg.characterId && user.user?._id === props.chat?.userId && false}>
-              <div class="text-200 ml-2 flex flex-row items-center gap-2">
-                <ThumbsUp size={14} class="hover:text-100 mt-[-0.15rem] cursor-pointer" />
-                <ThumbsDown size={14} class="hover:text-100 cursor-pointer" />
-              </div>
-            </Show>
           </div>
           <Show when={!edit() && !props.swipe && user.user?._id === props.chat?.userId}>
             <div
@@ -236,6 +230,11 @@ const SingleMessage: Component<
               )}
             />
           </Show>
+          <Show when={props.msg._id === ''}>
+            <div class="my-2 ml-4">
+              <div class="dot-flashing bg-[var(--hl-700)]"></div>
+            </div>
+          </Show>
           <Show when={edit()}>
             <div
               ref={ref}
@@ -244,6 +243,16 @@ const SingleMessage: Component<
                 if (ev.key === 'Escape') cancelEdit()
               }}
             ></div>
+          </Show>
+          <Show
+            when={
+              !edit() && props.msg.characterId && user.user?._id === props.chat?.userId && false
+            }
+          >
+            <div class="text-900 mt-2 flex flex-row items-center gap-2">
+              <ThumbsUp size={14} class="hover:text-600 mt-[-0.15rem] cursor-pointer" />
+              <ThumbsDown size={14} class="hover:text-600 cursor-pointer" />
+            </div>
           </Show>
         </div>
       </div>

--- a/web/pages/Chat/components/Message.tsx
+++ b/web/pages/Chat/components/Message.tsx
@@ -244,11 +244,7 @@ const SingleMessage: Component<
               }}
             ></div>
           </Show>
-          <Show
-            when={
-              !edit() && props.msg.characterId && user.user?._id === props.chat?.userId && false
-            }
-          >
+          <Show when={false}>
             <div class="text-900 mt-2 flex flex-row items-center gap-2">
               <ThumbsUp size={14} class="hover:text-600 mt-[-0.15rem] cursor-pointer" />
               <ThumbsDown size={14} class="hover:text-600 cursor-pointer" />

--- a/web/pages/Settings/index.tsx
+++ b/web/pages/Settings/index.tsx
@@ -214,7 +214,6 @@ const Settings: Component = () => {
                 type="password"
                 value={state.user?.oaiKey}
               />
-              <Loading />
               <Button schema="red" class="w-max" onClick={() => userStore.deleteKey('openai')}>
                 Delete OpenAI Key
               </Button>

--- a/web/shared/toggle.css
+++ b/web/shared/toggle.css
@@ -67,7 +67,6 @@
 }
 
 .toggle-checkbox {
-  position: absolute;
   visibility: hidden;
 }
 

--- a/web/store/user.ts
+++ b/web/store/user.ts
@@ -207,6 +207,10 @@ export const userStore = createStore<UserState>(
       if (kind === 'horde') {
         return { user: { ...user, hordeKey: '', hordeName: '' } }
       }
+
+      if (kind === 'claude') {
+        return { user: { ...user, claudeApiKey: '', claudeApiKeySet: false } }
+      }
     },
 
     clearGuestState() {


### PR DESCRIPTION
move flashing dots to an empty message
![image](https://user-images.githubusercontent.com/26354814/229302038-a7d7dbd1-3c89-4ae5-ba6e-8e93d1da9996.png)
make thumbs visible in dark mode (currently they're this very hard to see dark blue color)
move thumbs to bottom of message
![image](https://user-images.githubusercontent.com/26354814/229302017-17c3e3ae-8d7a-440b-8611-f63d3cd8a855.png)
fix toggle switch from making a bunch of extra scroll space in prompt tab of preset page (i had this on librewolf on linux and on edge on windows, other users said they had it too in the discord)
![image](https://user-images.githubusercontent.com/26354814/229302047-c4e85942-22b0-4997-aed7-6a82e3ca541b.png)
ws port bug fix?
feel free to discard changes in api.ts, maybe my nginx config was wrong but even though i was launching with `pnpm start:public` i wouldn't get messages back from openai and it would show in console it couldn't connect to the socket on port 1234 (because it's running on port 3001.) this fixed it for me

also my pnpm-lock.yaml file changed maybe add that to .gitignore idk if there's a reason it isn't in there