### PR TITLE
Fix Anti-Bond mode.

### DIFF
--- a/srv/adapter/openai.ts
+++ b/srv/adapter/openai.ts
@@ -86,7 +86,7 @@ export const handleOAI: ModelAdapter = async function* (opts) {
     body.prompt = prompt
   }
 
-  if (gen.antiBond) body.logit_bias = { 3938: 8, 11049: 8, 64186: 8, 42120: 8 }
+  if (gen.antiBond) body.logit_bias = { 3938: -50, 11049: -50, 64186: -50, 3717: -25 }
 
   const bearer = !!guest ? `Bearer ${user.oaiKey}` : `Bearer ${decryptText(user.oaiKey)}`
 


### PR DESCRIPTION
This was directly ported out of an implementation called "Bond mode" that increased the likelyhood of those words as a joke.  
Removed unrelated token that added a positive bias to the word " tomato", and added a slightly less powerful negative bias to the word " connection" that also is a common problematic word with GPT-4

Related token conversion list from the `cl100k_base.tiktoken` tokenizer:
IGZ1dHVyZQ=  -> 3938 == " future"
IGJvbmQ           -> 11049 == " bond"
IGJvbmRpbmc  -> 64186 == " bonding"
IHRvbWF0bw= -> 42120 == " tomato"