### PR TITLE
feat: Add Claude adapter and settings

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,4 +5,4 @@ INITIAL_PASSWORD=password
 DB_HOST=localhost
 DB_PORT=27017
 DB_NAME=agnai
-ADAPTERS=horde,novel,kobold,luminai,openai,scale
+ADAPTERS=horde,novel,kobold,luminai,openai,scale,claude

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ADD web/ ./web
 
 RUN pnpm run build:server && pnpm run build && mkdir -p /app/assets && echo "${SHA}" > /app/version.txt
 
-ENV ADAPTERS=horde,novel,kobold,luminai,openai,chai,scale \
+ENV ADAPTERS=horde,novel,kobold,luminai,openai,chai,scale,claude \
   LOG_LEVEL=info \
   INITIAL_USER=administrator \
   DB_NAME=agnai \

--- a/common/adapters.ts
+++ b/common/adapters.ts
@@ -36,8 +36,9 @@ export const OPENAI_MODELS = {
   GPT4: 'gpt-4',
 } as const
 
-/** Note: I'm claude-v1 and claude-instant-v1 not included as they may point
- * to different models in the future. Any new model names should be added manually.
+/** Note: claude-v1 and claude-instant-v1 not included as they may point
+ * to different models in the future. New models may be less appropriate
+ * for roleplaying so they should be updated to manually
  * <https://console.anthropic.com/docs/api/reference#-v1-complete>
  */
 export const CLAUDE_MODELS = {

--- a/common/adapters.ts
+++ b/common/adapters.ts
@@ -20,6 +20,7 @@ export const AI_ADAPTERS = [
   'luminai',
   'openai',
   'scale',
+  'claude',
 ] as const
 export const CHAT_ADAPTERS = ['default', ...AI_ADAPTERS] as const
 
@@ -33,6 +34,16 @@ export const OPENAI_MODELS = {
   DaVinci: 'text-davinci-003',
   Turbo: 'gpt-3.5-turbo',
   GPT4: 'gpt-4',
+} as const
+
+/** Note: I'm claude-v1 and claude-instant-v1 not included as they may point
+ * to different models in the future. Any new model names should be added manually.
+ * <https://console.anthropic.com/docs/api/reference#-v1-complete>
+ */
+export const CLAUDE_MODELS = {
+  'claude-v1.0': 'claude-v1.0',
+  'claude-v1.2': 'claude-v1.2',
+  'claude-instant-v1.0': 'claude-instant-v1.0',
 } as const
 
 export const NOVEL_MODELS = {
@@ -88,4 +99,5 @@ export const ADAPTER_LABELS: Record<AIAdapter, string> = {
   luminai: 'LuminAI',
   openai: 'OpenAI',
   scale: 'Scale',
+  claude: 'Claude',
 }

--- a/common/adapters.ts
+++ b/common/adapters.ts
@@ -2,6 +2,27 @@ export type AIAdapter = (typeof AI_ADAPTERS)[number]
 export type ChatAdapter = (typeof CHAT_ADAPTERS)[number]
 export type PersonaFormat = (typeof PERSONA_FORMATS)[number]
 
+export type AdapterSetting = {
+  /** The name of the field within the settings object */
+  field: string
+
+  /** The name as it appears in the Settings UI */
+  label: string
+
+  /** Any additional information about the setting (for UI only) */
+  helperText?: string
+
+  /** If this is a secret that should be encrypted */
+  secret: boolean
+}
+
+export type AdapterOptions = {
+  /** Name of the adapter that will be displayed in the UI */
+  label: string
+
+  settings: AdapterSetting[]
+}
+
 export const PERSONA_FORMATS = ['boostyle', 'wpp', 'sbf', 'text'] as const
 
 export const PERSONA_LABELS: { [key in PersonaFormat]: string } = {
@@ -42,9 +63,9 @@ export const OPENAI_MODELS = {
  * <https://console.anthropic.com/docs/api/reference#-v1-complete>
  */
 export const CLAUDE_MODELS = {
-  'claude-v1.0': 'claude-v1.0',
-  'claude-v1.2': 'claude-v1.2',
-  'claude-instant-v1.0': 'claude-instant-v1.0',
+  ClaudeV1: 'claude-v1.0',
+  ClaudeV1_2: 'claude-v1.2',
+  ClaudeInstantV1: 'claude-instant-v1.0',
 } as const
 
 export const NOVEL_MODELS = {

--- a/common/default-preset.ts
+++ b/common/default-preset.ts
@@ -124,7 +124,7 @@ This is how {{char}} should talk
   claude: {
     name: 'Claude V1.2',
     temp: 1,
-    claudeModel: CLAUDE_MODELS['claude-v1.2'],
+    claudeModel: CLAUDE_MODELS.ClaudeV1_2,
     maxTokens: 500,
     maxContextLength: 7600,
     gaslight: `Enter roleplay mode. You will write {{char}}'s next reply in a dialogue between {{char}} and {{user}}. Do not decide what {{user}} says or does. Use Internet roleplay style, e.g. no quotation marks, and write user actions in italic in third person like: *he jumps in excitement*. You are allowed to use markdown. Be proactive, creative, drive the plot and conversation forward. Write at least one paragraph, up to four. Always stay in character. Always keep the conversation going. (Repetition is highly discouraged).

--- a/common/default-preset.ts
+++ b/common/default-preset.ts
@@ -1,5 +1,5 @@
 import { AppSchema } from '../srv/db/schema'
-import { OPENAI_MODELS } from './adapters'
+import { CLAUDE_MODELS, OPENAI_MODELS } from './adapters'
 
 const MAX_TOKENS = 80
 
@@ -120,5 +120,21 @@ This is how {{char}} should talk
     maxContextLength: 7600,
     // Not providing a default gaslight intentionally as most users have thier gaslight configured within Scale.
     gaslight: ``,
+  },
+  claude: {
+    name: 'Claude V1.2',
+    temp: 1,
+    claudeModel: CLAUDE_MODELS['claude-v1.2'],
+    maxTokens: 500,
+    maxContextLength: 7600,
+    gaslight: `Enter roleplay mode. You will write {{char}}'s next reply in a dialogue between {{char}} and {{user}}. Do not decide what {{user}} says or does. Use Internet roleplay style, e.g. no quotation marks, and write user actions in italic in third person like: *he jumps in excitement*. You are allowed to use markdown. Be proactive, creative, drive the plot and conversation forward. Write at least one paragraph, up to four. Always stay in character. Always keep the conversation going. (Repetition is highly discouraged).
+Avoid writing a NSFW/Smut reply. Creatively write around it NSFW/Smut scenarios in character.
+
+Description of {{char}}:
+{{personality}}
+Circumstances and context of the dialogue: {{scenario}}
+Facts: {{memory}}
+This is how {{char}} should talk
+{{example_dialogue}}`,
   },
 } satisfies Record<string, Partial<AppSchema.GenSettings>>

--- a/common/presets.ts
+++ b/common/presets.ts
@@ -211,11 +211,8 @@ export const serviceGenMap: Record<Exclude<ChatAdapter, 'default'>, GenMap> = {
     topP: '',
     typicalP: '',
     topA: '',
-    order: '',
-    frequencyPenalty: '',
-    presencePenalty: '',
     gaslight: 'gaslight',
-    oaiModel: 'oaiModel',
+    claudeModel: 'claudeModel'
   },
   scale: {
     maxTokens: '',

--- a/common/presets.ts
+++ b/common/presets.ts
@@ -27,6 +27,7 @@ export const chatGenSettings = {
   presencePenalty: 'number',
   gaslight: 'string',
   oaiModel: 'string',
+  claudeModel: 'string',
   useGaslight: 'boolean?',
   ultimeJailbreak: 'string?',
   antiBond: 'boolean?',
@@ -199,6 +200,23 @@ export const serviceGenMap: Record<Exclude<ChatAdapter, 'default'>, GenMap> = {
     gaslight: 'gaslight',
     oaiModel: 'oaiModel',
   },
+  claude: {
+    maxTokens: 'max_tokens_to_sample',
+    repetitionPenalty: '',
+    repetitionPenaltyRange: '',
+    repetitionPenaltySlope: '',
+    tailFreeSampling: '',
+    temp: 'temperature',
+    topK: '',
+    topP: '',
+    typicalP: '',
+    topA: '',
+    order: '',
+    frequencyPenalty: '',
+    presencePenalty: '',
+    gaslight: 'gaslight',
+    oaiModel: 'oaiModel',
+  },
   scale: {
     maxTokens: '',
     repetitionPenalty: '',
@@ -240,5 +258,8 @@ export function getFallbackPreset(adapter: AIAdapter) {
 
     case 'scale':
       return defaultPresets.scale
+
+    case 'claude':
+      return defaultPresets.claude
   }
 }

--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -476,5 +476,8 @@ function getContextLimit(
 
     case 'scale':
       return configuredMax - genAmount
+
+    case 'claude':
+      return configuredMax - genAmount
   }
 }

--- a/srv/adapter/claude.ts
+++ b/srv/adapter/claude.ts
@@ -31,6 +31,7 @@ export const handleClaude: ModelAdapter = async function* (opts) {
     stop_sequences: [
       `\n\n${char.name}:`,
       `\n\n${username}:`,
+      `\n\nSystem:`,
       ...members.map((member) => `\n\n${member.handle}:`),
     ],
   }

--- a/srv/adapter/claude.ts
+++ b/srv/adapter/claude.ts
@@ -99,7 +99,8 @@ const mkPrompt = (opts: AdapterProps): string => {
   const maxContextLength = gen.maxContextLength || defaultPresets.claude.maxContextLength
   const maxResponseTokens = gen.maxTokens ?? defaultPresets.claude.maxTokens
   const gaslightCost = encoder('System: ' + parts.gaslight)
-  const ujbCost = gen.ultimeJailbreak ? encoder('System: ' + gen.ultimeJailbreak) : 0
+  const ujb = gen.ultimeJailbreak?.replace(BOT_REPLACE, char.name)?.replace(SELF_REPLACE, username)
+  const ujbCost = ujb ? encoder('System: ' + gen.ultimeJailbreak) : 0
   const maxBudget = maxContextLength - maxResponseTokens - gaslightCost - ujbCost
   const history = lines.map((ln) => lineToMsg(ln, char.name, username))
   const dropMsgUntilWithinBudget = (msgs: Msg[]): Msg[] =>
@@ -110,7 +111,7 @@ const mkPrompt = (opts: AdapterProps): string => {
   const messages = [
     { name: 'System', content: parts.gaslight },
     ...historyTruncated,
-    ...(gen.ultimeJailbreak ? [{ name: 'System', content: gen.ultimeJailbreak }] : []),
+    ...(ujb ? [{ name: 'System', content: ujb }] : []),
   ]
   // <https://console.anthropic.com/docs/prompt-design#what-is-a-prompt>
   return '\n\n' + messages.map(formatMsg).join('\n\n') + '\n\n' + char.name + ':'

--- a/srv/adapter/claude.ts
+++ b/srv/adapter/claude.ts
@@ -1,0 +1,117 @@
+import needle from 'needle'
+import { sanitise, trimResponseV2 } from '../api/chat/common'
+import { ModelAdapter, AdapterProps } from './type'
+import { decryptText } from '../db/util'
+import { defaultPresets } from '../../common/presets'
+import { BOT_REPLACE, SELF_REPLACE } from '../../common/prompt'
+import { getEncoder } from '../../common/tokenize'
+import { OPENAI_MODELS } from '../../common/adapters'
+
+// There's no tokenizer for Claude, we use OpenAI's as an estimation
+const encoder = getEncoder('openai', OPENAI_MODELS.Turbo)
+
+type Msg = {
+  name: string
+  content: string
+}
+
+export const handleClaude: ModelAdapter = async function* (opts) {
+  const { char, members, user, settings, log, guest, gen, sender } = opts
+  if (!user.claudeApiKey) {
+    yield { error: `Claude request failed: Claude API key not set. Check your settings.` }
+    return
+  }
+  const claudeModel = settings.claudeModel ?? defaultPresets.claude.claudeModel
+  const username = sender.handle || 'You'
+  const requestBody = {
+    model: claudeModel,
+    temperature: Math.min(1, Math.max(0, gen.temp ?? defaultPresets.claude.temp)),
+    max_tokens_to_sample: gen.maxTokens ?? defaultPresets.claude.maxTokens,
+    prompt: mkPrompt(opts),
+    stop_sequences: [
+      `\n\n${char.name}:`,
+      `\n\n${username}:`,
+      ...members.map((member) => `\n\n${member.handle}:`),
+    ],
+  }
+
+  log.debug(requestBody, 'Claude payload')
+
+  const url = `https://api.anthropic.com/v1/complete`
+  const resp = await needle('post', url, JSON.stringify(requestBody), {
+    json: true,
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': !!guest ? user.claudeApiKey : decryptText(user.claudeApiKey),
+    },
+  }).catch((err) => ({ error: err }))
+
+  if ('error' in resp) {
+    log.error({ error: resp.error }, 'Claude request failed to send')
+    yield { error: `Claude request failed: ${resp.error?.message || resp.error}` }
+    return
+  }
+
+  if (resp.statusCode && resp.statusCode >= 400) {
+    log.error({ body: resp.body }, `Claude request failed (${resp.statusCode})`)
+    yield { error: `Claude request failed: ${resp.statusMessage}` }
+    return
+  }
+
+  try {
+    const completion = resp.body.completion
+    if (!completion) {
+      log.error({ body: resp.body }, 'OpenAI request failed: Empty response')
+      yield { error: `OpenAI request failed: Received empty response. Try again.` }
+      return
+    } else {
+      const sanitised = sanitise(completion)
+      const trimmed = trimResponseV2(sanitised, char, members, ['END_OF_DIALOG'])
+      yield trimmed || sanitised
+      return
+    }
+  } catch (ex: any) {
+    log.error({ err: ex }, 'Claude failed to parse')
+    yield { error: `Claude request failed: ${ex.message}` }
+    return
+  }
+}
+
+const mkPrompt = (opts: AdapterProps): string => {
+  const lineToMsg = (line: string, charname: string, username: string): Msg => {
+    if (line === '<START>') {
+      return { name: 'System', content: line }
+    } else {
+      const name = line.split(':')[0] ?? 'You'
+      const lineUtterance = line.split(':')[1] ?? line
+      const content = lineUtterance
+        .trim()
+        .replace(BOT_REPLACE, charname)
+        .replace(SELF_REPLACE, username)
+      return { name, content }
+    }
+  }
+  const formatMsg = (msg: Msg): string => `${msg.name}: ${msg.content}`
+  const sum = (nums: number[]): number => nums.reduce((acc, cur) => acc + cur, 0)
+  const { char, sender, parts, gen } = opts
+  const username = sender.handle || 'You'
+  const lines = opts.lines ?? []
+  const maxContextLength = gen.maxContextLength || defaultPresets.claude.maxContextLength
+  const maxResponseTokens = gen.maxTokens ?? defaultPresets.claude.maxTokens
+  const gaslightCost = encoder('System: ' + parts.gaslight)
+  const ujbCost = gen.ultimeJailbreak ? encoder('System: ' + gen.ultimeJailbreak) : 0
+  const maxBudget = maxContextLength - maxResponseTokens - gaslightCost - ujbCost
+  const history = lines.map((ln) => lineToMsg(ln, char.name, username))
+  const dropMsgUntilWithinBudget = (msgs: Msg[]): Msg[] =>
+    sum(msgs.map((msg) => encoder(formatMsg(msg)))) <= maxBudget
+      ? msgs
+      : dropMsgUntilWithinBudget(msgs.slice(1))
+  const historyTruncated = dropMsgUntilWithinBudget(history)
+  const messages = [
+    { name: 'System', content: parts.gaslight },
+    ...historyTruncated,
+    ...(gen.ultimeJailbreak ? [{ name: 'System', content: gen.ultimeJailbreak }] : []),
+  ]
+  // <https://console.anthropic.com/docs/prompt-design#what-is-a-prompt>
+  return '\n\n' + messages.map(formatMsg).join('\n\n') + '\n\n' + char.name + ':'
+}

--- a/srv/adapter/generate.ts
+++ b/srv/adapter/generate.ts
@@ -17,6 +17,7 @@ import { handleLuminAI } from './luminai'
 import { handleNovel } from './novel'
 import { handleOoba } from './ooba'
 import { handleOAI } from './openai'
+import { handleClaude } from './claude'
 import { GenerateRequestV2, ModelAdapter } from './type'
 import { createPromptWithParts, getAdapter } from '../../common/prompt'
 import { handleScale } from './scale'
@@ -31,6 +32,7 @@ const handlers: { [key in AIAdapter]: ModelAdapter } = {
   luminai: handleLuminAI,
   openai: handleOAI,
   scale: handleScale,
+  claude: handleClaude,
 }
 
 export async function createTextStreamV2(

--- a/srv/adapter/register.ts
+++ b/srv/adapter/register.ts
@@ -1,0 +1,25 @@
+/**
+ * WIP
+ */
+
+import { AdapterOptions, AIAdapter } from '../../common/adapters'
+import { logger } from '../logger'
+import { ModelAdapter } from './type'
+
+const adapters = new Map<string, { name: string; handler: ModelAdapter; options: AdapterOptions }>()
+
+export function registerAdapter(name: AIAdapter, handler: ModelAdapter, options: AdapterOptions) {
+  if (adapters.has(name)) {
+    throw new Error(
+      `Cannot start: Attempted to register adapter '${name}', but it has already been registered`
+    )
+  }
+
+  logger.info(`Registered adapter: ${name}`)
+  adapters.set(name, { name, handler, options })
+}
+
+export function getRegisteredAdapters() {
+  const all = Array.from(adapters.values())
+  return all
+}

--- a/srv/adapter/type.ts
+++ b/srv/adapter/type.ts
@@ -34,7 +34,7 @@ export type AdapterProps = {
   sender: AppSchema.Profile
   prompt: string
   parts: PromptParts
-  lines?: string[]
+  lines: string[]
 
   /** GenSettings mapped to an object for the target adapter */
   gen: Partial<AppSchema.GenSettings>

--- a/srv/api/chat/message.ts
+++ b/srv/api/chat/message.ts
@@ -111,6 +111,7 @@ export const generateMessageV2 = handle(async ({ userId, body, socketId, params,
   res.json({ success: true, generating: true, message: 'Generating message' })
 
   const { stream, adapter } = await createTextStreamV2({ ...body, chat }, log, guest)
+
   log.setBindings({ adapter })
 
   let generated = ''

--- a/srv/api/settings.ts
+++ b/srv/api/settings.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import { readFile } from 'fs/promises'
 import { resolve } from 'path'
+import { getRegisteredAdapters } from '../adapter/register'
 import { config } from '../config'
 import { isConnected } from '../db/client'
 import { handle } from './wrap'
@@ -10,6 +11,10 @@ const router = Router()
 const appConfig: any = {
   adapters: config.adapters,
   version: null,
+  // adapterSettings: getRegisteredAdapters().map((adp) => ({
+  //   name: adp.name,
+  //   settings: adp.options.settings,
+  // })),
 }
 
 const getSettings = handle(async () => {

--- a/srv/api/user/index.ts
+++ b/srv/api/user/index.ts
@@ -7,6 +7,7 @@ import {
   deleteNovelKey,
   deleteOaiKey,
   deleteScaleKey,
+  deleteClaudeKey,
   getConfig,
   getInitialLoad,
   getProfile,
@@ -27,6 +28,7 @@ router.delete('/config/scale', loggedIn, deleteScaleKey)
 router.delete('/config/horde', loggedIn, deleteHordeKey)
 router.delete('/config/novel', loggedIn, deleteNovelKey)
 router.delete('/config/openai', loggedIn, deleteOaiKey)
+router.delete('/config/claude', loggedIn, deleteClaudeKey)
 router.delete('/presets/:id', loggedIn, deleteUserPreset)
 router.post('/password', loggedIn, changePassword)
 router.post('/config', loggedIn, updateConfig)

--- a/srv/api/user/settings.ts
+++ b/srv/api/user/settings.ts
@@ -5,7 +5,6 @@ import { config } from '../../config'
 import { store } from '../../db'
 import { AppSchema } from '../../db/schema'
 import { encryptText } from '../../db/util'
-import { personaValidator } from '../chat/common'
 import { findUser, HORDE_GUEST_KEY } from '../horde'
 import { get } from '../request'
 import { getAppConfig } from '../settings'
@@ -242,37 +241,11 @@ async function getSafeUserConfig(userId: string) {
       user.scaleApiKeySet = true
       user.scaleApiKey = ''
     }
+
+    if (user.claudeApiKey) {
+      user.claudeApiKey = ''
+      user.claudeApiKeySet = true
+    }
   }
   return user
-}
-
-function isSamePersona(left?: AppSchema.Persona, right?: AppSchema.Persona) {
-  if (!left || !right) {
-    if (!left && !right) return true
-    return false
-  }
-
-  if (left.kind === 'text' || right.kind === 'text') {
-    if (left.kind !== right.kind) return false
-    return left.attributes.text?.[0] === right.attributes.text?.[0]
-  }
-
-  const [keys, values] = Object.keys(left.attributes)
-
-  const leftSet = new Set(keys)
-  for (const key in right.attributes) {
-    leftSet.add(key)
-  }
-
-  if (leftSet.size !== keys.length) return false
-
-  for (const key of keys) {
-    const l = left.attributes[key]
-    const r = right.attributes[key]
-
-    const set = new Set(...l, ...r)
-    if (set.size !== l.length) return false
-  }
-
-  return true
 }

--- a/srv/api/user/settings.ts
+++ b/srv/api/user/settings.ts
@@ -44,6 +44,14 @@ export const deleteScaleKey = handle(async ({ userId }) => {
   return { success: true }
 })
 
+export const deleteClaudeKey = handle(async ({ userId }) => {
+  await store.users.updateUser(userId!, {
+    claudeApiKey: '',
+  })
+
+  return { success: true }
+})
+
 export const deleteHordeKey = handle(async ({ userId }) => {
   await store.users.updateUser(userId!, {
     hordeKey: '',
@@ -86,6 +94,7 @@ export const updateConfig = handle(async ({ userId, body }) => {
       defaultPresets: 'any',
       scaleUrl: 'string?',
       scaleApiKey: 'string?',
+      claudeApiKey: 'string?',
     },
     body
   )
@@ -150,6 +159,10 @@ export const updateConfig = handle(async ({ userId, body }) => {
   if (body.scaleUrl !== undefined) update.scaleUrl = body.scaleUrl
   if (body.scaleApiKey) {
     update.scaleApiKey = encryptText(body.scaleApiKey)
+  }
+
+  if (body.claudeApiKey) {
+    update.claudeApiKey = encryptText(body.claudeApiKey)
   }
 
   await store.users.updateUser(userId!, update)

--- a/srv/config.ts
+++ b/srv/config.ts
@@ -76,7 +76,7 @@ export const config = {
     username: env('INITIAL_USER', 'admin'),
     password: env('INITIAL_PASSWORD', v4()),
   },
-  adapters: env('ADAPTERS', 'novel,horde,kobold,chai,luminai,openai,scale')
+  adapters: env('ADAPTERS', 'novel,horde,kobold,chai,luminai,openai,scale,claude')
     .split(',')
     .filter((i) => !!i) as AIAdapter[],
 }

--- a/srv/db/schema.ts
+++ b/srv/db/schema.ts
@@ -48,11 +48,14 @@ export namespace AppSchema {
     scaleApiKeySet?: boolean
 
     claudeApiKey?: string
+    claudeApiKeySet?: boolean
 
     defaultAdapter: AIAdapter
     defaultPresets?: { [key in AIAdapter]?: string }
 
     createdAt?: string
+
+    // adapterConfig?: { [key in AIAdapter]?: Record<string, any> }
   }
 
   export interface Chat {

--- a/srv/db/schema.ts
+++ b/srv/db/schema.ts
@@ -47,6 +47,8 @@ export namespace AppSchema {
     scaleApiKey?: string
     scaleApiKeySet?: boolean
 
+    claudeApiKey?: string
+
     defaultAdapter: AIAdapter
     defaultPresets?: { [key in AIAdapter]?: string }
 
@@ -185,6 +187,7 @@ export namespace AppSchema {
     frequencyPenalty?: number
     presencePenalty?: number
     oaiModel?: string
+    claudeModel?: string
 
     memoryDepth?: number
     memoryContextLimit?: number

--- a/web/pages/Settings/WorkerModal.tsx
+++ b/web/pages/Settings/WorkerModal.tsx
@@ -1,0 +1,79 @@
+import { Save, X } from 'lucide-solid'
+import { Component, createSignal } from 'solid-js'
+import { HordeWorker } from '../../../common/adapters'
+import Button from '../../shared/Button'
+import Modal from '../../shared/Modal'
+import MultiDropdown from '../../shared/MultiDropdown'
+import { settingStore, userStore } from '../../store'
+import { Option } from '../../shared/Select'
+
+const WorkerModal: Component<{
+  show: boolean
+  close: () => void
+  save: (items: Option[]) => void
+}> = (props) => {
+  const cfg = settingStore((s) => ({
+    workers: s.workers.slice().sort(sortWorkers).map(toWorkerItem),
+  }))
+
+  const state = userStore()
+
+  const [selected, setSelected] = createSignal<Option[]>()
+
+  const save = () => {
+    if (selected()) {
+      props.save(selected()!)
+    } else if (state.user?.hordeWorkers) {
+      props.save(cfg.workers.filter((w) => state.user?.hordeWorkers!.includes(w.value)))
+    }
+
+    props.close()
+  }
+
+  return (
+    <Modal
+      show={props.show}
+      close={props.close}
+      title="Specify AI Horde Workers"
+      footer={
+        <>
+          <Button schema="secondary" onClick={props.close}>
+            <X /> Cancel
+          </Button>
+          <Button onClick={save}>
+            <Save /> Select Workers
+          </Button>
+        </>
+      }
+    >
+      <div class="flex flex-col gap-4 text-sm">
+        <MultiDropdown
+          fieldName="workers"
+          items={cfg.workers}
+          label="Select Workers"
+          helperText="To use any worker de-select all workers"
+          onChange={setSelected}
+          values={selected()?.map((s) => s.value) || state.user?.hordeWorkers || []}
+        />
+        <div class="flex items-center justify-between gap-4">
+          <div>
+            Workers selected: {selected()?.length || state.user?.hordeWorkers?.length || '0'}
+          </div>
+          <Button schema="gray" class="w-max" onClick={() => setSelected([])}>
+            De-select All
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
+export default WorkerModal
+
+function sortWorkers({ models: l }: HordeWorker, { models: r }: HordeWorker) {
+  return l[0] > r[0] ? 1 : l[0] === r[0] ? 0 : -1
+}
+
+function toWorkerItem(wkr: HordeWorker): Option {
+  return { label: `${wkr.name} - ${wkr.models[0]}`, value: wkr.id }
+}

--- a/web/pages/Settings/index.tsx
+++ b/web/pages/Settings/index.tsx
@@ -64,6 +64,7 @@ const Settings: Component = () => {
       oaiKey: 'string?',
       scaleApiKey: 'string?',
       scaleUrl: 'string?',
+      claudeApiKey: 'string?',
       defaultAdapter: adapterOptions,
     } as const)
 
@@ -207,6 +208,25 @@ const Settings: Component = () => {
               />
               <Button schema="red" class="w-max" onClick={() => userStore.deleteKey('openai')}>
                 Delete OpenAI Key
+              </Button>
+            </Show>
+
+            <Show when={cfg.config.adapters.includes('claude')}>
+              <Divider />
+              <TextInput
+                fieldName="claudeApiKey"
+                label="Claude Key"
+                helperText="Valid Claude Key."
+                placeholder={
+                  ((!state.user?.claudeApiKey))
+                    ? 'Claude key is set'
+                    : 'E.g. sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+                }
+                type="password"
+                value={state.user?.claudeApiKey}
+              />
+              <Button schema="red" class="w-max" onClick={() => userStore.deleteKey('claude')}>
+                Delete Claude Key
               </Button>
             </Show>
 

--- a/web/pages/Settings/index.tsx
+++ b/web/pages/Settings/index.tsx
@@ -1,25 +1,18 @@
 import { Component, createEffect, createMemo, createSignal, Show } from 'solid-js'
-import { AlertTriangle, RefreshCw, Save, X } from 'lucide-solid'
+import { AlertTriangle, RefreshCw, Save } from 'lucide-solid'
 import Button from '../../shared/Button'
 import PageHeader from '../../shared/PageHeader'
 import TextInput from '../../shared/TextInput'
 import { adaptersToOptions, getFormEntries, getStrictForm } from '../../shared/util'
 import Select, { Option } from '../../shared/Select'
-import {
-  CHAT_ADAPTERS,
-  ChatAdapter,
-  HordeModel,
-  HordeWorker,
-  AIAdapter,
-} from '../../../common/adapters'
+import { CHAT_ADAPTERS, ChatAdapter, HordeModel, AIAdapter } from '../../../common/adapters'
 import { settingStore, userStore } from '../../store'
 import Divider from '../../shared/Divider'
-import MultiDropdown from '../../shared/MultiDropdown'
-import Modal from '../../shared/Modal'
 import { DefaultPresets } from './DefaultPresets'
 import { AppSchema } from '../../../srv/db/schema'
 import UISettings from './UISettings'
 import Tabs from '../../shared/Tabs'
+import WorkerModal from './WorkerModal'
 
 const settingTabs = {
   ai: 'AI Settings',
@@ -218,7 +211,7 @@ const Settings: Component = () => {
                 label="Claude Key"
                 helperText="Valid Claude Key."
                 placeholder={
-                  ((!state.user?.claudeApiKey))
+                  state.user?.claudeApiKeySet
                     ? 'Claude key is set'
                     : 'E.g. sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
                 }
@@ -331,78 +324,9 @@ const Settings: Component = () => {
 
 export default Settings
 
-const WorkerModal: Component<{
-  show: boolean
-  close: () => void
-  save: (items: Option[]) => void
-}> = (props) => {
-  const cfg = settingStore((s) => ({
-    workers: s.workers.slice().sort(sortWorkers).map(toWorkerItem),
-  }))
-
-  const state = userStore()
-
-  const [selected, setSelected] = createSignal<Option[]>()
-
-  const save = () => {
-    if (selected()) {
-      props.save(selected()!)
-    } else if (state.user?.hordeWorkers) {
-      props.save(cfg.workers.filter((w) => state.user?.hordeWorkers!.includes(w.value)))
-    }
-
-    props.close()
-  }
-
-  return (
-    <Modal
-      show={props.show}
-      close={props.close}
-      title="Specify AI Horde Workers"
-      footer={
-        <>
-          <Button schema="secondary" onClick={props.close}>
-            <X /> Cancel
-          </Button>
-          <Button onClick={save}>
-            <Save /> Select Workers
-          </Button>
-        </>
-      }
-    >
-      <div class="flex flex-col gap-4 text-sm">
-        <MultiDropdown
-          fieldName="workers"
-          items={cfg.workers}
-          label="Select Workers"
-          helperText="To use any worker de-select all workers"
-          onChange={setSelected}
-          values={selected()?.map((s) => s.value) || state.user?.hordeWorkers || []}
-        />
-        <div class="flex items-center justify-between gap-4">
-          <div>
-            Workers selected: {selected()?.length || state.user?.hordeWorkers?.length || '0'}
-          </div>
-          <Button schema="gray" class="w-max" onClick={() => setSelected([])}>
-            De-select All
-          </Button>
-        </div>
-      </div>
-    </Modal>
-  )
-}
-
 function toItem(model: HordeModel) {
   return {
     label: `${model.name} - (queue: ${model.queued}, eta: ${model.eta}, count: ${model.count})`,
     value: model.name,
   }
-}
-
-function sortWorkers({ models: l }: HordeWorker, { models: r }: HordeWorker) {
-  return l[0] > r[0] ? 1 : l[0] === r[0] ? 0 : -1
-}
-
-function toWorkerItem(wkr: HordeWorker): Option {
-  return { label: `${wkr.name} - ${wkr.models[0]}`, value: wkr.id }
 }

--- a/web/shared/GenerationSettings.tsx
+++ b/web/shared/GenerationSettings.tsx
@@ -1,10 +1,10 @@
 import { Component, createSignal, Show } from 'solid-js'
 import RangeInput from './RangeInput'
 import TextInput from './TextInput'
-import Select from './Select'
+import Select, { Option } from './Select'
 import { AppSchema } from '../../srv/db/schema'
 import { defaultPresets } from '../../common/presets'
-import { OPENAI_MODELS } from '../../common/adapters'
+import { OPENAI_MODELS, CLAUDE_MODELS } from '../../common/adapters'
 import Divider from './Divider'
 import { Toggle } from './Toggle'
 import Tabs from './Tabs'
@@ -71,11 +71,11 @@ const GeneralSettings: Component<Props> = (props) => {
           <>
             <p>
               Maximum context length. Typically 2048 for most models. OpenAI supports up to 4K.
-              Scale supports up to 8K. If you set this too high, you may get unexpected results or
+              Scale and Claude support up to 8K. If you set this too high, you may get unexpected results or
               errors.
             </p>
             <p>
-              We don't have a GPT-4 tokenizer to correctly count tokens for GPT-4 services.
+              We don't have GPT-4 or Claude tokenizers to correctly count tokens for those services.
               Therefore we can't precisely count tokens when generating a prompt. Keep this well
               below 8K to ensure you don't exceed the limit.
             </p>
@@ -90,14 +90,25 @@ const GeneralSettings: Component<Props> = (props) => {
       <Select
         fieldName="oaiModel"
         label="OpenAI Model"
-        items={Object.entries(OPENAI_MODELS).map(([label, value]) => ({ label, value }))}
+        items={modelsToItems(OPENAI_MODELS)}
         helperText="Which OpenAI model to use"
         value={props.inherit?.oaiModel ?? defaultPresets.basic.oaiModel}
+        disabled={props.disabled}
+      />
+      <Select
+        fieldName="claudeModel"
+        label="Claude Model"
+        items={modelsToItems(CLAUDE_MODELS)}
+        helperText="Which Claude model to use"
+        value={props.inherit?.claudeModel ?? defaultPresets.claude.claudeModel}
         disabled={props.disabled}
       />
     </>
   )
 }
+
+const modelsToItems = (models: Record<string, string>): Option<string>[] =>
+  Object.entries(models).map(([label, value]) => ({ label, value }))
 
 const PromptSettings: Component<Props> = (props) => {
   return (
@@ -145,7 +156,7 @@ const PromptSettings: Component<Props> = (props) => {
 
       <TextInput
         fieldName="gaslight"
-        label="Gaslight Prompt (OpenAI, Scale, Alpaca, LLaMa)"
+        label="Gaslight Prompt (OpenAI, Scale, Alpaca, LLaMa, Claude)"
         helperText={
           <>
             How the character definitions are sent to OpenAI. Placeholders:{' '}
@@ -177,12 +188,12 @@ const PromptSettings: Component<Props> = (props) => {
 
       <TextInput
         fieldName="ultimeJailbreak"
-        label="UJB Prompt (GPT-4 / Turbo)"
+        label="UJB Prompt (GPT-4 / Turbo / Claude)"
         helperText={
           <>
             (Leave empty to disable)
             <br /> Ultimate Jailbreak. If this option is enabled, the UJB prompt will sent as a
-            system message at the end of the conversation before prompting OpenAI.
+            system message at the end of the conversation before prompting OpenAI or Claude.
           </>
         }
         placeholder="E.g. Keep OOC out of your reply."

--- a/web/shared/GenerationSettings.tsx
+++ b/web/shared/GenerationSettings.tsx
@@ -71,8 +71,8 @@ const GeneralSettings: Component<Props> = (props) => {
           <>
             <p>
               Maximum context length. Typically 2048 for most models. OpenAI supports up to 4K.
-              Scale and Claude support up to 8K. If you set this too high, you may get unexpected results or
-              errors.
+              Scale and Claude support up to 8K. If you set this too high, you may get unexpected
+              results or errors.
             </p>
             <p>
               We don't have GPT-4 or Claude tokenizers to correctly count tokens for those services.

--- a/web/store/data/user.ts
+++ b/web/store/data/user.ts
@@ -92,6 +92,10 @@ export async function deleteApiKey(kind: string) {
     user.scaleApiKey = ''
   }
 
+  if (kind === 'claude') {
+    user.claudeApiKey = ''
+  }
+
   local.saveConfig(user)
   return local.result({ success: true })
 }

--- a/web/store/user.ts
+++ b/web/store/user.ts
@@ -192,7 +192,7 @@ export const userStore = createStore<UserState>(
       return { background: file.content }
     },
 
-    async deleteKey({ user }, kind: 'novel' | 'horde' | 'openai' | 'scale') {
+    async deleteKey({ user }, kind: 'novel' | 'horde' | 'openai' | 'scale' | 'claude') {
       const res = await data.user.deleteApiKey(kind)
       if (res.error) return toastStore.error(`Failed to update settings: ${res.error}`)
 


### PR DESCRIPTION
Claude adapter added.

User can add their Claude API key by going to their "Settings" in the left navigation drawer:

![1680704041](https://user-images.githubusercontent.com/128472336/230108094-a47e4260-ac15-4f46-b9fc-a9091634c4d2.png)

In Preset General Settings, a new Claude Model field is added under "OpenAI Model" (the default is sensible and does not need to be changed):

![1680704161](https://user-images.githubusercontent.com/128472336/230108637-b58fc82a-ee48-449c-82e0-4b442c4d246b.png)

When starting a chat, users who have another service than Claude set to default must go to the Chat Settings menu and select Claude:

![1680704626](https://user-images.githubusercontent.com/128472336/230110939-fe9377b4-69a4-42f8-8b27-229a962ea2e9.png)

Preset settings that Claude supports (This is communicated in the Preset settings):
- Temperature (clamped between 0 and 1)
- Max tokens
- UJB
- Memory: Context Limit and Chat History Depth
- Gaslight

Note that we don't have a Claude tokenizer, so we rely on estimates. This is communicated in the settings menu. That part I didn't communicate, but the Claude API warns that going over the token limit will cause nonsensical replies.