### PR TITLE
Feat: Delete chat from the chat details screen's top right menu

### DIFF
--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -16,7 +16,6 @@ import ChatMemoryModal from './components/MemoryModal'
 import Message from './components/Message'
 import PromptModal from './components/PromptModal'
 import DeleteMsgModal from './DeleteMsgModal'
-import './chat-detail.css'
 import { DropMenu } from '../../shared/DropMenu'
 import UISettings from '../Settings/UISettings'
 import { devCycleAvatarSettings, isDevCommand } from './dev-util'
@@ -26,6 +25,8 @@ import { AppSchema } from '../../../srv/db/schema'
 import { ImageModal } from './ImageModal'
 import { getClientPreset } from '../../shared/adapter'
 import ForcePresetModal from './ForcePreset'
+import DeleteChatModal from './components/DeleteChat'
+import './chat-detail.css'
 
 const EDITING_KEY = 'chat-detail-settings'
 
@@ -340,6 +341,10 @@ const ChatDetail: Component = () => {
 
       <Show when={modal() === 'export'}>
         <ChatExport show={true} close={setModal} />
+      </Show>
+
+      <Show when={modal() === 'delete'}>
+        <DeleteChatModal show={true} chat={chats.chat!} redirect={true} close={setModal} />
       </Show>
 
       <Show when={!!removeId()}>

--- a/web/pages/Chat/ChatOptions.tsx
+++ b/web/pages/Chat/ChatOptions.tsx
@@ -1,4 +1,14 @@
-import { Book, Download, MailPlus, Palette, Settings, Sliders, Users, Camera } from 'lucide-solid'
+import {
+  Book,
+  Download,
+  MailPlus,
+  Palette,
+  Settings,
+  Sliders,
+  Trash,
+  Users,
+  Camera,
+} from 'lucide-solid'
 import { Component, Show, createMemo } from 'solid-js'
 import Button from '../../shared/Button'
 import { Toggle } from '../../shared/Toggle'
@@ -6,7 +16,15 @@ import { chatStore, settingStore, toastStore, userStore } from '../../store'
 import { domToPng } from 'modern-screenshot'
 import { getRootRgb, getRootVariable } from '../../shared/util'
 
-export type ChatModal = 'export' | 'settings' | 'invite' | 'memory' | 'gen' | 'ui' | 'members'
+export type ChatModal =
+  | 'export'
+  | 'settings'
+  | 'invite'
+  | 'memory'
+  | 'gen'
+  | 'ui'
+  | 'members'
+  | 'delete'
 
 const ChatOptions: Component<{
   show: (modal: ChatModal) => void
@@ -141,6 +159,15 @@ const ChatOptions: Component<{
       >
         <Download /> Export Chat
       </Option>
+
+      <Show when={isOwner()}>
+        <Option
+          onClick={() => props.show('delete')}
+          class="flex justify-start gap-2 hover:bg-[var(--bg-700)]"
+        >
+          <Trash /> Delete Chat
+        </Option>
+      </Show>
     </div>
   )
 }

--- a/web/pages/Chat/components/DeleteChat.tsx
+++ b/web/pages/Chat/components/DeleteChat.tsx
@@ -4,15 +4,22 @@ import { AppSchema } from '../../../../srv/db/schema'
 import Button from '../../../shared/Button'
 import Modal from '../../../shared/Modal'
 import { chatStore } from '../../../store'
+import { Navigate, useNavigate } from '@solidjs/router'
 
 const DeleteChatModal: Component<{
   chat?: AppSchema.Chat
   show: boolean
+  redirect?: boolean
   close: () => void
 }> = (props) => {
+  const nav = useNavigate()
+
   const onDelete = () => {
     if (!props.chat) return
     chatStore.deleteChat(props.chat?._id, props.close)
+    if (props.redirect) {
+      nav(`/character/${props.chat?.characterId}/chats`)
+    }
   }
   return (
     <Modal


### PR DESCRIPTION
Solves #145

Also note that this uses `chats.chat` which has been changed to `chat()` in https://github.com/luminai-companion/agn-ai/pull/146#issuecomment-1497779191 - logically #146 should be merged first, then this commit should be updated to use `chat()` to make sure we are using the correct chat at all times.