### PR TITLE
UX: Improved chats list

### DIFF
--- a/.github/agn.docker-compose.yml
+++ b/.github/agn.docker-compose.yml
@@ -26,7 +26,7 @@ services:
       CHAI_URL: /run/secrets/chai_url
       CHAI_UID: /run/secrets/chai_uid
       CHAI_KEY: /run/secrets/chai_token
-      ADAPTERS: horde,novel,kobold,openai,scale
+      ADAPTERS: horde,novel,kobold,openai,scale,claude
     secrets:
       - jwt_secret
       - chai_url

--- a/common/presets.ts
+++ b/common/presets.ts
@@ -212,7 +212,7 @@ export const serviceGenMap: Record<Exclude<ChatAdapter, 'default'>, GenMap> = {
     typicalP: '',
     topA: '',
     gaslight: 'gaslight',
-    claudeModel: 'claudeModel'
+    claudeModel: 'claudeModel',
   },
   scale: {
     maxTokens: '',
@@ -258,5 +258,8 @@ export function getFallbackPreset(adapter: AIAdapter) {
 
     case 'claude':
       return defaultPresets.claude
+
+    default:
+      throw new Error(`Unknown adapter: ${adapter}`)
   }
 }

--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -479,5 +479,8 @@ function getContextLimit(
 
     case 'claude':
       return configuredMax - genAmount
+
+    default:
+      throw new Error(`Unknown adapter: ${adapter}`)
   }
 }

--- a/web/pages/Character/ChatList.tsx
+++ b/web/pages/Character/ChatList.tsx
@@ -1,9 +1,9 @@
-import { useNavigate, useParams } from '@solidjs/router'
+import { A, useNavigate, useParams } from '@solidjs/router'
 import { Component, createEffect, createSignal, For, Show } from 'solid-js'
 import { AllChat, characterStore, chatStore } from '../../store'
 import PageHeader from '../../shared/PageHeader'
 import Button from '../../shared/Button'
-import { Import, Plus, Trash } from 'lucide-solid'
+import { ChevronLeft, Edit, Import, Plus, Trash } from 'lucide-solid'
 import CreateChatModal from './CreateChat'
 import ImportChatModal from './ImportChat'
 import { toDuration, toEntityMap } from '../../shared/util'
@@ -12,6 +12,7 @@ import AvatarIcon from '../../shared/AvatarIcon'
 
 const CharacterChats: Component = () => {
   const params = useParams()
+  const nav = useNavigate()
   const [showCreate, setCreate] = createSignal(false)
   const [showImport, setImport] = createSignal(false)
 
@@ -33,21 +34,39 @@ const CharacterChats: Component = () => {
 
   return (
     <div class="flex flex-col gap-2">
-      <Show when={!!params.id} fallback={<PageHeader title="Chats" />}>
-        <PageHeader title={`Chats with ${state.char?.name || '...'}`} />
-      </Show>
+      <PageHeader title="Chats" />
 
-      <div class="flex w-full justify-end gap-2">
-        <Button onClick={() => setImport(true)}>
-          <Import />
-          Import
-        </Button>
-        <Button onClick={() => setCreate(true)}>
-          <Plus />
-          Chat
-        </Button>
+      <div class="mx-auto flex h-full flex-col justify-between sm:py-2 w-full">
+        <div class="flex h-8 items-center justify-between rounded-md">
+          <div class="flex cursor-pointer flex-row items-center justify-between gap-4 text-lg font-bold">
+            <A href={`/character/list`}>
+              <ChevronLeft />
+            </A>
+            <Show when={!!params.id} fallback={<span>Chats (all characters)</span>}>
+              <span>Chats with {state.char?.name || "..."}</span>
+            </Show>
+          </div>
+
+          <div class="flex flex-row gap-3">
+            <Button onClick={() => setImport(true)}>
+              <Import />
+              Import
+            </Button>
+            <Show when={!!params.id}>
+              <Button onClick={() => nav(`/character/${params.id}/edit`)}>
+                <Edit />
+                Edit Character
+              </Button>
+            </Show>
+            <Button onClick={() => setCreate(true)}>
+              <Plus />
+              Chat
+            </Button>
+          </div>
+        </div>
       </div>
-      {state.chats.length === 0 && <NoChats />}
+
+      {state.chats.length === 0 && <NoChats character={state.char?.name} />}
       <Show when={state.chats.length}>
         <Chats chats={state.chats} />
       </Show>
@@ -109,9 +128,14 @@ const Chats: Component<{ chats: AllChat[] }> = (props) => {
   )
 }
 
-const NoChats: Component = () => (
+const NoChats: Component<{ character?: string }> = (props) => (
   <div class="mt-4 flex w-full justify-center text-xl">
-    There are no conversations saved for this character. Get started!
+    <Show when={!props.character}>
+      You have no conversations yet.
+    </Show>
+    <Show when={props.character}>
+      You have no conversations with <i>{props.character}</i>.
+    </Show>
   </div>
 )
 

--- a/web/pages/Character/ChatList.tsx
+++ b/web/pages/Character/ChatList.tsx
@@ -1,20 +1,22 @@
 import { A, useNavigate, useParams } from '@solidjs/router'
-import { Component, createEffect, createSignal, For, Show } from 'solid-js'
+import { Component, createEffect, createMemo, createSignal, For, Show } from 'solid-js'
 import { AllChat, characterStore, chatStore } from '../../store'
 import PageHeader from '../../shared/PageHeader'
 import Button from '../../shared/Button'
-import { ChevronLeft, Edit, Import, Plus, Trash } from 'lucide-solid'
+import { ChevronLeft, Edit, Import, Menu, Plus, Trash } from 'lucide-solid'
 import CreateChatModal from './CreateChat'
 import ImportChatModal from './ImportChat'
 import { toDuration, toEntityMap } from '../../shared/util'
 import { ConfirmModal } from '../../shared/Modal'
 import AvatarIcon from '../../shared/AvatarIcon'
+import { DropMenu } from '../../shared/DropMenu'
 
 const CharacterChats: Component = () => {
   const params = useParams()
   const nav = useNavigate()
   const [showCreate, setCreate] = createSignal(false)
   const [showImport, setImport] = createSignal(false)
+  const [opts, setOpts] = createSignal(false)
 
   const state = chatStore((s) => {
     if (params.id) {
@@ -32,36 +34,67 @@ const CharacterChats: Component = () => {
     }
   })
 
+  const wrap = (fn: Function) => () => {
+    fn()
+    setOpts(false)
+  }
+
+  const Options = () => (
+    <>
+      <button
+        class={`btn-primary w-full items-center justify-start py-2 sm:w-fit sm:justify-center`}
+        onClick={wrap(() => setImport(true))}
+      >
+        <Import />
+        Import
+      </button>
+      <Show when={!!params.id}>
+        <button
+          class={`btn-primary w-full items-center justify-start py-2 sm:w-fit sm:justify-center`}
+          onClick={wrap(() => nav(`/character/${params.id}/edit`))}
+        >
+          <Edit />
+          Edit Character
+        </button>
+      </Show>
+      <button
+        class={`btn-primary w-full items-center justify-start py-2 sm:w-fit sm:justify-center`}
+        onClick={wrap(() => setCreate(true))}
+      >
+        <Plus />
+        Chat
+      </button>
+    </>
+  )
+
   return (
     <div class="flex flex-col gap-2">
       <PageHeader title="Chats" />
 
-      <div class="mx-auto flex h-full flex-col justify-between sm:py-2 w-full">
+      <div class="mx-auto flex h-full w-full flex-col justify-between sm:py-2">
         <div class="flex h-8 items-center justify-between rounded-md">
           <div class="flex cursor-pointer flex-row items-center justify-between gap-4 text-lg font-bold">
             <A href={`/character/list`}>
               <ChevronLeft />
             </A>
             <Show when={!!params.id} fallback={<span>Chats (all characters)</span>}>
-              <span>Chats with {state.char?.name || "..."}</span>
+              <span>Chats with {state.char?.name || '...'}</span>
             </Show>
           </div>
 
-          <div class="flex flex-row gap-3">
-            <Button onClick={() => setImport(true)}>
-              <Import />
-              Import
-            </Button>
-            <Show when={!!params.id}>
-              <Button onClick={() => nav(`/character/${params.id}/edit`)}>
-                <Edit />
-                Edit Character
-              </Button>
+          <div class="hidden gap-3 sm:flex">
+            <Options />
+          </div>
+
+          <div class="sm:hidden" onClick={() => setOpts(true)}>
+            <Menu class="icon-button" />
+            <Show when={opts()}>
+              <DropMenu show={true} close={() => setOpts(false)} horz="left">
+                <div class="flex w-60 flex-col gap-2 p-2">
+                  <Options />
+                </div>
+              </DropMenu>
             </Show>
-            <Button onClick={() => setCreate(true)}>
-              <Plus />
-              Chat
-            </Button>
           </div>
         </div>
       </div>
@@ -130,9 +163,7 @@ const Chats: Component<{ chats: AllChat[] }> = (props) => {
 
 const NoChats: Component<{ character?: string }> = (props) => (
   <div class="mt-4 flex w-full justify-center text-xl">
-    <Show when={!props.character}>
-      You have no conversations yet.
-    </Show>
+    <Show when={!props.character}>You have no conversations yet.</Show>
     <Show when={props.character}>
       You have no conversations with <i>{props.character}</i>.
     </Show>

--- a/web/pages/Chat/ChatOptions.tsx
+++ b/web/pages/Chat/ChatOptions.tsx
@@ -94,7 +94,7 @@ const Option: Component<{
     props.close?.()
   }
   return (
-    <Button schema="secondary" size="sm" onClick={onClick}>
+    <Button schema="secondary" size="sm" onClick={onClick} alignLeft>
       {props.children}
     </Button>
   )

--- a/web/pages/Chat/components/InputBar.tsx
+++ b/web/pages/Chat/components/InputBar.tsx
@@ -84,6 +84,7 @@ const InputBar: Component<{
                 schema="secondary"
                 class="w-full"
                 onClick={() => props.more(state.lastMsg.msg)}
+                alignLeft
               >
                 <PlusCircle size={18} /> Generate More
               </Button>

--- a/web/pages/Chat/components/MemoryModal.tsx
+++ b/web/pages/Chat/components/MemoryModal.tsx
@@ -70,24 +70,22 @@ const ChatMemoryModal: Component<{
       fixedHeight
     >
       <div class="flex flex-col gap-2">
-        <div class="flex items-end justify-between">
-          <Select
-            fieldName="memoryId"
-            label="Chat Memory Book"
-            helperText="The memory book your chat will use"
-            items={[{ label: 'None', value: '' }].concat(state.items)}
-            value={id()}
-            onChange={(item) => changeBook(item.value)}
-          />
-          <Button
-            disabled={id() === (props.chat.memoryId || '')}
-            class="h-fit w-fit"
-            onClick={useMemoryBook}
-          >
-            <Save />
-            Use Memory Book
-          </Button>
-        </div>
+        <Select
+          fieldName="memoryId"
+          label="Chat Memory Book"
+          helperText="The memory book your chat will use"
+          items={[{ label: 'None', value: '' }].concat(state.items)}
+          value={id()}
+          onChange={(item) => changeBook(item.value)}
+        />
+        <Button
+          disabled={id() === (props.chat.memoryId || '')}
+          class="h-fit w-fit"
+          onClick={useMemoryBook}
+        >
+          <Save />
+          Use Memory Book
+        </Button>
         <Divider />
 
         <Show when={book()}>

--- a/web/shared/Button.tsx
+++ b/web/shared/Button.tsx
@@ -29,12 +29,14 @@ const Button: Component<{
   size?: 'sm' | 'md' | 'lg'
   disabled?: boolean
   class?: string
+  alignLeft?: boolean
 }> = (props) => (
   <button
     type={props.type || 'button'}
     class={
-      `${kinds[props.schema || 'primary']} select-none items-center ${sizes[props.size || 'md']} ` +
-      props.class
+      `${kinds[props.schema || 'primary']} select-none items-center ${
+        props.alignLeft ? '' : 'justify-center'
+      } ${sizes[props.size || 'md']} ` + props.class
     }
     disabled={props.disabled}
     onClick={props.onClick}


### PR DESCRIPTION
Chats list:

![image](https://user-images.githubusercontent.com/34192666/230262047-cee22da6-1320-4df1-bdaa-ef4a55ee9c20.png)

Character-specific chats list:

![image](https://user-images.githubusercontent.com/34192666/230262081-23311fca-a414-4d7b-ad71-9c2d74f183aa.png)

Changes:

- Chevron to go back to the characters list
- Button to edit the character directly from the list of chats for that character
- Change the "Chats with NAME" title to be just "Chats" with the name below
- Fix the "No chats with this character" when no character is selected (different messages)
