### PR TITLE
chore: add local app URLs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ If you're only looking to run AgnAI without contributing:
      - This will install the dependencies using `pnpm v6`
    - `npm run build:all`
    - Build and run the project in watch mode:
-     - Mac/Linux: `npm run start`
-     - Windows: `npm run start:win`
+     - Mac/Linux: `npm run start` (access the app at `localhost:1234`)
+     - Windows: `npm run start:win` (access the app at `localhost:3001`)
    - Build and run the project with Local Tunnel:
      - Mac/Linux: `npm run start:public`
      - Windows: `npm run start:public:win`
+     - Your app URL will be printed at the beginning of the console output.
 
 ## Design Goals
 


### PR DESCRIPTION
Users reported having trouble finding the agnai local URL. Further, it seems the URL is not printed to the console output on Windows. This PR adds it to the README.

**IMPORTANT**: this was made with the following **unverified** assumptions:
- the port on Linux and Mac is always 1234
- the port on Windows is always 3001