### PR TITLE
feat: add support for more third party backend formats under Kobold settings

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,7 +4,7 @@ permissions:
   # This is required for actions/checkout
   contents: read
 
-on: push
+on: pull_request
 
 env:
   node-version: '18.4.0'

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ version.txt
 !srv.tsconfig.json
 settings.json
 .npmrc
+.model

--- a/common/dummy.ts
+++ b/common/dummy.ts
@@ -33,7 +33,7 @@ export function toProfile(name: string): AppSchema.Profile {
 }
 
 export function toUser(name: string): AppSchema.User {
-  return {
+  const user: AppSchema.User = {
     _id: name,
     username: name,
     hordeKey: '',
@@ -43,13 +43,14 @@ export function toUser(name: string): AppSchema.User {
     hash: '',
     kind: 'user',
     koboldUrl: '',
-    thirdPartyBackendFormat: 'kobold',
+    thirdPartyFormat: 'kobold',
     luminaiUrl: '',
     novelApiKey: '',
     novelModel: NOVEL_MODELS.krake,
     oaiKey: '',
     oobaUrl: '',
   }
+  return user
 }
 
 export function toBotMsg(

--- a/common/dummy.ts
+++ b/common/dummy.ts
@@ -43,6 +43,7 @@ export function toUser(name: string): AppSchema.User {
     hash: '',
     kind: 'user',
     koboldUrl: '',
+    thirdPartyBackendFormat: 'kobold',
     luminaiUrl: '',
     novelApiKey: '',
     novelModel: NOVEL_MODELS.krake,

--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -375,20 +375,24 @@ function sortMessagesDesc(l: AppSchema.ChatMessage, r: AppSchema.ChatMessage) {
   return l.createdAt > r.createdAt ? -1 : l.createdAt === r.createdAt ? 0 : 1
 }
 
-const ADAPTERS_WITH_THIRD_PARTY_COMPATIBLE_API_SUPPORTED = ['openai', 'claude']
+const THIRD_PARTY_ADAPTERS: { [key in AIAdapter]?: boolean } = {
+  openai: true,
+  claude: true,
+}
 
 export function getAdapter(
   chat: AppSchema.Chat,
   config: AppSchema.User,
   preset?: Partial<AppSchema.GenSettings>
 ) {
-  const configAdapter =
+  const chatAdapter =
     !chat.adapter || chat.adapter === 'default' ? config.defaultAdapter : chat.adapter
+
   const adapter =
-    configAdapter === 'kobold' &&
-    ADAPTERS_WITH_THIRD_PARTY_COMPATIBLE_API_SUPPORTED.includes(config.thirdPartyBackendFormat)
-      ? config.thirdPartyBackendFormat
-      : configAdapter
+    chatAdapter === 'kobold' && THIRD_PARTY_ADAPTERS[config.thirdPartyFormat]
+      ? config.thirdPartyFormat
+      : chatAdapter
+
   let model = ''
   let presetName = 'Fallback Preset'
 

--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -375,17 +375,19 @@ function sortMessagesDesc(l: AppSchema.ChatMessage, r: AppSchema.ChatMessage) {
   return l.createdAt > r.createdAt ? -1 : l.createdAt === r.createdAt ? 0 : 1
 }
 
+const ADAPTERS_WITH_THIRD_PARTY_COMPATIBLE_API_SUPPORTED = ['openai', 'claude']
+
 export function getAdapter(
   chat: AppSchema.Chat,
   config: AppSchema.User,
   preset?: Partial<AppSchema.GenSettings>
 ) {
   const configAdapter =
-    !chat.adapter
-      || chat.adapter === 'default' ? config.defaultAdapter : chat.adapter
+    !chat.adapter || chat.adapter === 'default' ? config.defaultAdapter : chat.adapter
   const adapter =
-    configAdapter === 'kobold' && config.thirdPartyBackendFormat === 'openai'
-      ? 'openai'
+    configAdapter === 'kobold' &&
+    ADAPTERS_WITH_THIRD_PARTY_COMPATIBLE_API_SUPPORTED.includes(config.thirdPartyBackendFormat)
+      ? config.thirdPartyBackendFormat
       : configAdapter
   let model = ''
   let presetName = 'Fallback Preset'

--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -380,7 +380,13 @@ export function getAdapter(
   config: AppSchema.User,
   preset?: Partial<AppSchema.GenSettings>
 ) {
-  let adapter = !chat.adapter || chat.adapter === 'default' ? config.defaultAdapter : chat.adapter
+  const configAdapter =
+    !chat.adapter
+      || chat.adapter === 'default' ? config.defaultAdapter : chat.adapter
+  const adapter =
+    configAdapter === 'kobold' && config.thirdPartyBackendFormat === 'openai'
+      ? 'openai'
+      : configAdapter
   let model = ''
   let presetName = 'Fallback Preset'
 

--- a/srv/adapter/claude.ts
+++ b/srv/adapter/claude.ts
@@ -6,6 +6,9 @@ import { defaultPresets } from '../../common/presets'
 import { BOT_REPLACE, SELF_REPLACE } from '../../common/prompt'
 import { getEncoder } from '../../common/tokenize'
 import { OPENAI_MODELS } from '../../common/adapters'
+import { AppSchema } from '../db/schema'
+
+const baseUrl = `https://api.anthropic.com/v1/complete`
 
 // There's no tokenizer for Claude, we use OpenAI's as an estimation
 const encoder = getEncoder('openai', OPENAI_MODELS.Turbo)
@@ -16,9 +19,7 @@ export const handleClaude: ModelAdapter = async function* (opts) {
     yield { error: `Claude request failed: Claude API key not set. Check your settings.` }
     return
   }
-  const officialBaseUrl = `https://api.anthropic.com/v1/complete`
-  const url =
-    user.thirdPartyBackendFormat === 'claude' ? user.koboldUrl || officialBaseUrl : officialBaseUrl
+  const base = getBaseUrl(user)
   const claudeModel = settings.claudeModel ?? defaultPresets.claude.claudeModel
   const username = sender.handle || 'You'
 
@@ -37,15 +38,19 @@ export const handleClaude: ModelAdapter = async function* (opts) {
     stop_sequences: Array.from(stops),
   }
 
-  console.log(requestBody)
+  const headers: any = {
+    'Content-Type': 'application/json',
+  }
+
+  if (!base.changed) {
+    headers['x-api-key'] = !!guest ? user.claudeApiKey : decryptText(user.claudeApiKey)
+  }
+
   log.debug(requestBody, 'Claude payload')
 
-  const resp = await needle('post', url, JSON.stringify(requestBody), {
+  const resp = await needle('post', base.url, JSON.stringify(requestBody), {
     json: true,
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': !!guest ? user.claudeApiKey : decryptText(user.claudeApiKey),
-    },
+    headers,
   }).catch((err) => ({ error: err }))
 
   if ('error' in resp) {
@@ -77,6 +82,14 @@ export const handleClaude: ModelAdapter = async function* (opts) {
     yield { error: `Claude request failed: ${ex.message}` }
     return
   }
+}
+
+function getBaseUrl(user: AppSchema.User) {
+  if (user.thirdPartyFormat === 'claude' && user.koboldUrl) {
+    return { url: user.koboldUrl, changed: true }
+  }
+
+  return { url: baseUrl, changed: false }
 }
 
 function createClaudePrompt(opts: AdapterProps): string {

--- a/srv/adapter/claude.ts
+++ b/srv/adapter/claude.ts
@@ -16,7 +16,9 @@ export const handleClaude: ModelAdapter = async function* (opts) {
     yield { error: `Claude request failed: Claude API key not set. Check your settings.` }
     return
   }
-
+  const officialBaseUrl = `https://api.anthropic.com/v1/complete`
+  const url =
+    user.thirdPartyBackendFormat === 'claude' ? user.koboldUrl || officialBaseUrl : officialBaseUrl
   const claudeModel = settings.claudeModel ?? defaultPresets.claude.claudeModel
   const username = sender.handle || 'You'
 
@@ -35,9 +37,8 @@ export const handleClaude: ModelAdapter = async function* (opts) {
     stop_sequences: Array.from(stops),
   }
 
+  console.log(requestBody)
   log.debug(requestBody, 'Claude payload')
-
-  const url = `https://api.anthropic.com/v1/complete`
 
   const resp = await needle('post', url, JSON.stringify(requestBody), {
     json: true,

--- a/srv/adapter/openai.ts
+++ b/srv/adapter/openai.ts
@@ -8,7 +8,7 @@ import { getEncoder } from '../../common/tokenize'
 import { OPENAI_MODELS } from '../../common/adapters'
 import { StatusError } from '../api/wrap'
 
-const baseUrl = `https://api.openai.com`
+const openAiBaseUrl = `https://api.openai.com`
 
 type OpenAIMessagePropType = {
   role: 'user' | 'assistant' | 'system'
@@ -28,6 +28,8 @@ export const handleOAI: ModelAdapter = async function* (opts) {
     return
   }
   const oaiModel = settings.oaiModel ?? defaultPresets.openai.oaiModel
+  const baseUrl =
+    user.thirdPartyBackendFormat === 'openai' ? user.koboldUrl || openAiBaseUrl : openAiBaseUrl
 
   const body: any = {
     model: oaiModel,
@@ -172,7 +174,7 @@ export async function getOpenAIUsage(oaiKey: string, guest: boolean): Promise<OA
 
   const res = await needle(
     'get',
-    `${baseUrl}/dashboard/billing/usage?start_date=${start_date}&end_date=${end_date}`,
+    `${openAiBaseUrl}/dashboard/billing/usage?start_date=${start_date}&end_date=${end_date}`,
     { headers }
   )
   if (res.statusCode && res.statusCode >= 400) {

--- a/srv/adapter/openai.ts
+++ b/srv/adapter/openai.ts
@@ -113,6 +113,7 @@ export const handleOAI: ModelAdapter = async function* (opts) {
   log.debug(body, 'OpenAI payload')
 
   const url = useChat ? `${baseUrl}/v1/chat/completions` : `${baseUrl}/v1/completions`
+  console.log(body)
   const resp = await needle('post', url, JSON.stringify(body), {
     json: true,
     headers,

--- a/srv/api/user/settings.ts
+++ b/srv/api/user/settings.ts
@@ -130,7 +130,6 @@ export const updateConfig = handle(async ({ userId, body }) => {
     update.hordeKey = encryptText(incomingKey)
   }
 
-  console.log(body.thirdPartyBackendFormat === 'kobold')
   const validatedThirdPartyUrl =
     body.thirdPartyBackendFormat === 'kobold'
       ? await verifyKobldUrl(prevUser, body.koboldUrl)

--- a/srv/api/user/settings.ts
+++ b/srv/api/user/settings.ts
@@ -83,7 +83,7 @@ export const updateConfig = handle(async ({ userId, body }) => {
       novelApiKey: 'string?',
       novelModel: 'string?',
       koboldUrl: 'string?',
-      thirdPartyBackendFormat: 'string?',
+      thirdPartyFormat: 'string?',
       hordeUseTrusted: 'boolean?',
       hordeApiKey: 'string?',
       hordeKey: 'string?',
@@ -131,7 +131,7 @@ export const updateConfig = handle(async ({ userId, body }) => {
   }
 
   const validatedThirdPartyUrl =
-    body.thirdPartyBackendFormat === 'kobold'
+    body.thirdPartyFormat === 'kobold'
       ? await verifyKobldUrl(prevUser, body.koboldUrl)
       : body.koboldUrl
 

--- a/srv/api/user/settings.ts
+++ b/srv/api/user/settings.ts
@@ -83,6 +83,7 @@ export const updateConfig = handle(async ({ userId, body }) => {
       novelApiKey: 'string?',
       novelModel: 'string?',
       koboldUrl: 'string?',
+      thirdPartyBackendFormat: 'string?',
       hordeUseTrusted: 'boolean?',
       hordeApiKey: 'string?',
       hordeKey: 'string?',
@@ -129,9 +130,14 @@ export const updateConfig = handle(async ({ userId, body }) => {
     update.hordeKey = encryptText(incomingKey)
   }
 
-  const validKoboldUrl = await verifyKobldUrl(prevUser, body.koboldUrl)
+  console.log(body.thirdPartyBackendFormat === 'kobold')
+  const validatedThirdPartyUrl =
+    body.thirdPartyBackendFormat === 'kobold'
+      ? await verifyKobldUrl(prevUser, body.koboldUrl)
+      : body.koboldUrl
 
-  if (validKoboldUrl !== undefined) update.koboldUrl = validKoboldUrl
+  if (validatedThirdPartyUrl) update.koboldUrl = validatedThirdPartyUrl
+
   if (body.luminaiUrl !== undefined) update.luminaiUrl = body.luminaiUrl
 
   if (body.hordeModel) {

--- a/srv/db/schema.ts
+++ b/srv/db/schema.ts
@@ -32,7 +32,7 @@ export namespace AppSchema {
     novelVerified?: boolean
 
     koboldUrl: string
-    thirdPartyBackendFormat: 'kobold' | 'openai' | 'claude'
+    thirdPartyFormat: 'kobold' | 'openai' | 'claude'
     luminaiUrl: string
     oobaUrl: string
 

--- a/srv/db/schema.ts
+++ b/srv/db/schema.ts
@@ -32,6 +32,7 @@ export namespace AppSchema {
     novelVerified?: boolean
 
     koboldUrl: string
+    thirdPartyBackendFormat: 'kobold' | 'openai'
     luminaiUrl: string
     oobaUrl: string
 

--- a/srv/db/schema.ts
+++ b/srv/db/schema.ts
@@ -32,7 +32,7 @@ export namespace AppSchema {
     novelVerified?: boolean
 
     koboldUrl: string
-    thirdPartyBackendFormat: 'kobold' | 'openai'
+    thirdPartyBackendFormat: 'kobold' | 'openai' | 'claude'
     luminaiUrl: string
     oobaUrl: string
 

--- a/srv/db/user.ts
+++ b/srv/db/user.ts
@@ -91,6 +91,7 @@ export async function createUser(newUser: NewUser, admin?: boolean) {
     novelApiKey: '',
     defaultAdapter: 'horde',
     koboldUrl: '',
+    thirdPartyBackendFormat: 'kobold',
     novelModel: NOVEL_MODELS.euterpe,
     luminaiUrl: '',
     oobaUrl: '',

--- a/srv/db/user.ts
+++ b/srv/db/user.ts
@@ -91,7 +91,7 @@ export async function createUser(newUser: NewUser, admin?: boolean) {
     novelApiKey: '',
     defaultAdapter: 'horde',
     koboldUrl: '',
-    thirdPartyBackendFormat: 'kobold',
+    thirdPartyFormat: 'kobold',
     novelModel: NOVEL_MODELS.euterpe,
     luminaiUrl: '',
     oobaUrl: '',

--- a/web/pages/Settings/components/KoboldAISettings.tsx
+++ b/web/pages/Settings/components/KoboldAISettings.tsx
@@ -1,4 +1,5 @@
 import { Component } from 'solid-js'
+import Select from '../../../shared/Select'
 import TextInput from '../../../shared/TextInput'
 import { userStore } from '../../../store'
 
@@ -7,9 +8,18 @@ const KoboldAISettings: Component = () => {
 
   return (
     <>
+      <Select
+        fieldName="thirdPartyBackendFormat"
+        label="Third party backend format"
+        items={[
+          { label: 'Kobold', value: 'kobold' },
+          { label: 'OpenAI', value: 'openai' },
+        ]}
+        value={state.user?.thirdPartyBackendFormat}
+      />
       <TextInput
         fieldName="koboldUrl"
-        label="Kobold Compatible URL"
+        label="Third-party backend URL"
         helperText="Fully qualified URL. This URL must be publicly accessible."
         placeholder="E.g. https://local-tunnel-url-10-20-30-40.loca.lt"
         value={state.user?.koboldUrl}

--- a/web/pages/Settings/components/KoboldAISettings.tsx
+++ b/web/pages/Settings/components/KoboldAISettings.tsx
@@ -8,22 +8,24 @@ const KoboldAISettings: Component = () => {
 
   return (
     <>
+      <TextInput
+        fieldName="koboldUrl"
+        label="Kobold-compatible / 3rd-party URL"
+        helperText="Fully qualified URL. Typically for Kobold. This URL must be publicly accessible."
+        placeholder="E.g. https://local-tunnel-url-10-20-30-40.loca.lt"
+        value={state.user?.koboldUrl}
+      />
+
       <Select
-        fieldName="thirdPartyBackendFormat"
-        label="Third party backend format"
+        fieldName="thirdPartyFormat"
+        label="Kobold / 3rd-party Format"
+        helperText="Re-formats the prompt to the desired output format."
         items={[
           { label: 'Kobold', value: 'kobold' },
           { label: 'OpenAI', value: 'openai' },
           { label: 'Claude', value: 'claude' },
         ]}
-        value={state.user?.thirdPartyBackendFormat}
-      />
-      <TextInput
-        fieldName="koboldUrl"
-        label="Third-party backend URL"
-        helperText="Fully qualified URL. This URL must be publicly accessible."
-        placeholder="E.g. https://local-tunnel-url-10-20-30-40.loca.lt"
-        value={state.user?.koboldUrl}
+        value={state.user?.thirdPartyFormat}
       />
     </>
   )

--- a/web/pages/Settings/components/KoboldAISettings.tsx
+++ b/web/pages/Settings/components/KoboldAISettings.tsx
@@ -14,6 +14,7 @@ const KoboldAISettings: Component = () => {
         items={[
           { label: 'Kobold', value: 'kobold' },
           { label: 'OpenAI', value: 'openai' },
+          { label: 'Claude', value: 'claude' },
         ]}
         value={state.user?.thirdPartyBackendFormat}
       />

--- a/web/pages/Settings/components/KoboldAISettings.tsx
+++ b/web/pages/Settings/components/KoboldAISettings.tsx
@@ -25,7 +25,7 @@ const KoboldAISettings: Component = () => {
           { label: 'OpenAI', value: 'openai' },
           { label: 'Claude', value: 'claude' },
         ]}
-        value={state.user?.thirdPartyFormat}
+        value={state.user?.thirdPartyFormat ?? 'kobold'}
       />
     </>
   )

--- a/web/pages/Settings/index.tsx
+++ b/web/pages/Settings/index.tsx
@@ -36,6 +36,7 @@ const Settings: Component = () => {
   const onSubmit = (evt: Event) => {
     const body = getStrictForm(evt, {
       koboldUrl: 'string?',
+      thirdPartyBackendFormat: ['kobold', 'openai'],
       novelApiKey: 'string?',
       novelModel: 'string?',
       hordeUseTrusted: 'boolean?',

--- a/web/pages/Settings/index.tsx
+++ b/web/pages/Settings/index.tsx
@@ -36,7 +36,7 @@ const Settings: Component = () => {
   const onSubmit = (evt: Event) => {
     const body = getStrictForm(evt, {
       koboldUrl: 'string?',
-      thirdPartyBackendFormat: ['kobold', 'openai'],
+      thirdPartyBackendFormat: ['kobold', 'openai', 'claude'],
       novelApiKey: 'string?',
       novelModel: 'string?',
       hordeUseTrusted: 'boolean?',

--- a/web/pages/Settings/index.tsx
+++ b/web/pages/Settings/index.tsx
@@ -36,7 +36,7 @@ const Settings: Component = () => {
   const onSubmit = (evt: Event) => {
     const body = getStrictForm(evt, {
       koboldUrl: 'string?',
-      thirdPartyBackendFormat: ['kobold', 'openai', 'claude'],
+      thirdPartyFormat: ['kobold', 'openai', 'claude'],
       novelApiKey: 'string?',
       novelModel: 'string?',
       hordeUseTrusted: 'boolean?',

--- a/web/store/data/storage.ts
+++ b/web/store/data/storage.ts
@@ -78,6 +78,7 @@ const fallbacks: { [key in StorageKey]: LocalStorage[key] } = {
     hordeModel: 'PygmalionAI/pygmalion-6b',
     defaultAdapter: 'horde',
     koboldUrl: '',
+    thirdPartyBackendFormat: 'kobold',
     luminaiUrl: '',
   },
   profile: { _id: '', kind: 'profile', userId: ID, handle: 'You' },

--- a/web/store/data/storage.ts
+++ b/web/store/data/storage.ts
@@ -78,7 +78,7 @@ const fallbacks: { [key in StorageKey]: LocalStorage[key] } = {
     hordeModel: 'PygmalionAI/pygmalion-6b',
     defaultAdapter: 'horde',
     koboldUrl: '',
-    thirdPartyBackendFormat: 'kobold',
+    thirdPartyFormat: 'kobold',
     luminaiUrl: '',
   },
   profile: { _id: '', kind: 'profile', userId: ID, handle: 'You' },


### PR DESCRIPTION
Makes the "Kobold" settings able to support more third-party backend formats than just Kobold. This commits adds support for backends using the OpenAI format. In the future more will be added, e.g. ooba.

This adds a new "Third party backend format" under the Kobold settings tab. If "OpenAI" is chosen then requests will be made using the OpenAI adapter, but with the provided backend URL as a baseUrl.

The name for the "Kobold" settings category is no longer fully accurate but we've deferred naming issues for now.

![1681574463](https://user-images.githubusercontent.com/128472336/232235790-2f876a6a-7566-4873-8db3-810f5fa37a1a.png)
