### PR TITLE
Claude old versions deprecation notice

### DIFF
--- a/common/adapters.ts
+++ b/common/adapters.ts
@@ -63,10 +63,12 @@ export const OPENAI_MODELS = {
  * <https://console.anthropic.com/docs/api/reference#-v1-complete>
  */
 export const CLAUDE_MODELS = {
-  ClaudeV1: 'claude-v1.0',
+  ClaudeV1: 'claude-v1 ',
+  ClaudeV1_0: 'claude-v1.0',
   ClaudeV1_2: 'claude-v1.2',
   ClaudeV1_3: 'claude-v1.3',
-  ClaudeInstantV1: 'claude-instant-v1.0',
+  ClaudeInstantV1: 'claude-instant-v1',
+  ClaudeInstantV1_0: 'claude-instant-v1.0',
 } as const
 
 export const NOVEL_MODELS = {

--- a/common/default-preset.ts
+++ b/common/default-preset.ts
@@ -147,9 +147,9 @@ This is how {{char}} should talk
     gaslight: ``,
   },
   claude: {
-    name: 'Claude V1.2',
+    name: 'Claude V1',
     temp: 1,
-    claudeModel: CLAUDE_MODELS.ClaudeV1_3,
+    claudeModel: CLAUDE_MODELS.ClaudeV1,
     maxTokens: 500,
     maxContextLength: 7600,
     gaslight: `Enter roleplay mode. You will write {{char}}'s next reply in a dialogue between {{char}} and {{user}}. Do not decide what {{user}} says or does. Use Internet roleplay style, e.g. no quotation marks, and write user actions in italic in third person like: *he jumps in excitement*. You are allowed to use markdown. Be proactive, creative, drive the plot and conversation forward. Write at least one paragraph, up to four. Always stay in character. Always keep the conversation going. (Repetition is highly discouraged).

--- a/web/pages/Character/ChatList.tsx
+++ b/web/pages/Character/ChatList.tsx
@@ -163,10 +163,12 @@ const Chats: Component<{ chats: AllChat[] }> = (props) => {
 
 const NoChats: Component<{ character?: string }> = (props) => (
   <div class="mt-4 flex w-full justify-center text-xl">
-    <Show when={!props.character}>You have no conversations yet.</Show>
-    <Show when={props.character}>
-      You have no conversations with <i>{props.character}</i>.
-    </Show>
+    <div>
+      <Show when={!props.character}>You have no conversations yet.</Show>
+      <Show when={props.character}>
+        You have no conversations with <i>{props.character}</i>.
+      </Show>
+    </div>
   </div>
 )
 


### PR DESCRIPTION
Claude sent a notification that v1.2 and earlier would be deprecated soon, and to use v1 instead of v1.x.

This commit does that, so we don't have to update the preset so often.

I also included an unrelated fix for empty chat lists for a character, a space was missing (I added a div, it's probably not the best way but it's pretty harmless)