### PR TITLE
[self-hosting] don't expose mongodb port

### DIFF
--- a/self-host.docker-compose.yml
+++ b/self-host.docker-compose.yml
@@ -1,5 +1,8 @@
 version: '2'
 
+networks:
+  backend:
+
 services:
   app:
     image: ghcr.io/luminai-companion/agnaistic:latest
@@ -13,9 +16,11 @@ services:
       - INITIAL_USER=admin
       - INITIAL_PASSWORD=password
       - JWT_SECRET=self-hosting
+    networks: 
+      - backend
     
   mongo:
     image: mongo:6
     restart: always
-    ports:
-      - '27017:27017'
+    networks:
+      - backend


### PR DESCRIPTION
This changes the `self-host.docker-compose.yml` config to use a docker network, so that only the app container can access the mongodb service.