### PR TITLE
fix: default claude model had an extra space (and hence didn't work)

### DIFF
--- a/common/adapters.ts
+++ b/common/adapters.ts
@@ -63,7 +63,7 @@ export const OPENAI_MODELS = {
  * <https://console.anthropic.com/docs/api/reference#-v1-complete>
  */
 export const CLAUDE_MODELS = {
-  ClaudeV1: 'claude-v1 ',
+  ClaudeV1: 'claude-v1',
   ClaudeV1_0: 'claude-v1.0',
   ClaudeV1_2: 'claude-v1.2',
   ClaudeV1_3: 'claude-v1.3',


### PR DESCRIPTION
title

breaks claude in production for most users as it is the default setting, so should be merged fast