### PR TITLE
fix: save third party format on agnai.chat

### DIFF
--- a/srv/api/user/settings.ts
+++ b/srv/api/user/settings.ts
@@ -138,6 +138,10 @@ export const updateConfig = handle(async ({ userId, body }) => {
 
   if (validatedThirdPartyUrl) update.koboldUrl = validatedThirdPartyUrl
 
+  if (body.thirdPartyFormat) {
+    update.thirdPartyFormat = body.thirdPartyFormat as typeof update.thirdPartyFormat
+  }
+
   if (body.luminaiUrl !== undefined) update.luminaiUrl = body.luminaiUrl
 
   if (body.images) {


### PR DESCRIPTION
Bug: Saving third party format in Kobold settings worked locally but not on agnai.chat

This should fix it, but I couldn't reproduce the bug locally; I'm not actually sure how to turn on DB storage locally