### PR TITLE
add volume to self-hosted docker yml

### DIFF
--- a/self-host.docker-compose.yml
+++ b/self-host.docker-compose.yml
@@ -1,5 +1,8 @@
 version: '2'
 
+volumes:
+  dbdata:
+
 networks:
   backend:
 
@@ -22,5 +25,7 @@ services:
   mongo:
     image: mongo:6
     restart: always
+    volumes:
+      - dbdata:/data/db
     networks:
       - backend


### PR DESCRIPTION
this is to avoid the footgun of all local data disappearing when turning off the self-hosted containers from the provided docker-compose file