### PR TITLE
fix: don't require API key for 3rd-party backends, indicate on chat UI if using 3rd party backend

### DIFF
--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -391,8 +391,10 @@ export function getAdapter(
   const chatAdapter =
     !chat.adapter || chat.adapter === 'default' ? config.defaultAdapter : chat.adapter
 
+  const isThirdParty = THIRD_PARTY_ADAPTERS[config.thirdPartyFormat]
+
   const adapter =
-    chatAdapter === 'kobold' && THIRD_PARTY_ADAPTERS[config.thirdPartyFormat]
+    chatAdapter === 'kobold' && isThirdParty
       ? config.thirdPartyFormat
       : chatAdapter
 
@@ -423,7 +425,7 @@ export function getAdapter(
 
   const contextLimit = getContextLimit(preset, adapter, model)
 
-  return { adapter, model, preset: presetName, contextLimit }
+  return { adapter, model, preset: presetName, contextLimit, isThirdParty }
 }
 
 /**

--- a/srv/adapter/claude.ts
+++ b/srv/adapter/claude.ts
@@ -15,11 +15,11 @@ const encoder = getEncoder('openai', OPENAI_MODELS.Turbo)
 
 export const handleClaude: ModelAdapter = async function* (opts) {
   const { char, members, user, settings, log, guest, gen, sender } = opts
-  if (!user.claudeApiKey) {
+  const base = getBaseUrl(user)
+  if (!user.claudeApiKey && !base.changed) {
     yield { error: `Claude request failed: Claude API key not set. Check your settings.` }
     return
   }
-  const base = getBaseUrl(user)
   const claudeModel = settings.claudeModel ?? defaultPresets.claude.claudeModel
   const username = sender.handle || 'You'
 
@@ -43,7 +43,7 @@ export const handleClaude: ModelAdapter = async function* (opts) {
   }
 
   if (!base.changed) {
-    headers['x-api-key'] = !!guest ? user.claudeApiKey : decryptText(user.claudeApiKey)
+    headers['x-api-key'] = !!guest ? user.claudeApiKey : decryptText(user.claudeApiKey!)
   }
 
   log.debug(requestBody, 'Claude payload')

--- a/srv/adapter/openai.ts
+++ b/srv/adapter/openai.ts
@@ -24,12 +24,12 @@ const CHAT_MODELS: Record<string, boolean> = {
 export const handleOAI: ModelAdapter = async function* (opts) {
   const { char, members, user, prompt, settings, sender, log, guest, lines, parts, gen, kind } =
     opts
-  if (!user.oaiKey) {
+  const base = getBaseUrl(user)
+  if (!user.oaiKey && !base.changed) {
     yield { error: `OpenAI request failed: Not OpenAI API key not set. Check your settings.` }
     return
   }
   const oaiModel = settings.oaiModel ?? defaultPresets.openai.oaiModel
-  const base = getBaseUrl(user)
 
   const body: any = {
     model: oaiModel,

--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -110,7 +110,7 @@ const ChatDetail: Component = () => {
     if (chats.chat.userId !== user.user._id) return ''
 
     const { adapter, preset, isThirdParty } = getAdapter(chats.chat!, user.user!)
-    const label = `${ADAPTER_LABELS[adapter]}${isThirdParty ? " (3rd party)" : ''} - ${preset}`
+    const label = `${ADAPTER_LABELS[adapter]}${isThirdParty ? ' (3rd party)' : ''} - ${preset}`
     return label
   })
 

--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -109,8 +109,8 @@ const ChatDetail: Component = () => {
     if (!chats.chat || !user.user) return ''
     if (chats.chat.userId !== user.user._id) return ''
 
-    const { adapter, preset } = getAdapter(chats.chat!, user.user!)
-    const label = `${ADAPTER_LABELS[adapter]} - ${preset}`
+    const { adapter, preset, isThirdParty } = getAdapter(chats.chat!, user.user!)
+    const label = `${ADAPTER_LABELS[adapter]}${isThirdParty ? " (3rd party)" : ''} - ${preset}`
     return label
   })
 


### PR DESCRIPTION
- Using a non-Kobold third-party backend no longer requires the user to set an API key (it's never sent anyway)
- Previously, if using an e.g. 3rd-party Claude-compatible backend, the chat UI would show "Claude" at the top of the viewport, now it'll show "Claude (3rd party)"