### PR TITLE
fix: small fixes relating to 3rd party urls

### DIFF
--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -431,7 +431,7 @@ export function getAdapter(
   const chatAdapter =
     !chat.adapter || chat.adapter === 'default' ? config.defaultAdapter : chat.adapter
 
-  const isThirdParty = THIRD_PARTY_ADAPTERS[config.thirdPartyFormat]
+  const isThirdParty = THIRD_PARTY_ADAPTERS[config.thirdPartyFormat] && chatAdapter === 'kobold'
 
   const adapter =
     chatAdapter === 'kobold' && isThirdParty

--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -410,8 +410,8 @@ export function getChatPreset(
   }
 
   // #3
-  const { adapter } = getAdapter(chat, user)
-  const fallbackId = user.defaultPresets?.[adapter]
+  const { adapter, isThirdParty } = getAdapter(chat, user)
+  const fallbackId = user.defaultPresets?.[isThirdParty ? 'kobold' : adapter]
 
   if (fallbackId) {
     if (isDefaultPreset(fallbackId)) return defaultPresets[fallbackId]
@@ -433,10 +433,7 @@ export function getAdapter(
 
   const isThirdParty = THIRD_PARTY_ADAPTERS[config.thirdPartyFormat] && chatAdapter === 'kobold'
 
-  const adapter =
-    chatAdapter === 'kobold' && isThirdParty
-      ? config.thirdPartyFormat
-      : chatAdapter
+  const adapter = chatAdapter === 'kobold' && isThirdParty ? config.thirdPartyFormat : chatAdapter
 
   let model = ''
   let presetName = 'Fallback Preset'

--- a/srv/api/user/settings.ts
+++ b/srv/api/user/settings.ts
@@ -136,7 +136,11 @@ export const updateConfig = handle(async ({ userId, body }) => {
       ? await verifyKobldUrl(prevUser, body.koboldUrl)
       : body.koboldUrl
 
-  if (validatedThirdPartyUrl) update.koboldUrl = validatedThirdPartyUrl
+  if (validatedThirdPartyUrl) {
+    update.koboldUrl = validatedThirdPartyUrl
+  } else {
+    update.koboldUrl = ''
+  }
 
   if (body.thirdPartyFormat) {
     update.thirdPartyFormat = body.thirdPartyFormat as typeof update.thirdPartyFormat


### PR DESCRIPTION
So sorry for needing so many PRs to get this right...

- #205 showed "3rd party" in chat details even if you were using normal OAI/Claude, in the case where you'd also set your Kobold format to OAI/Claude. This PR fixes it so that "3rd party" is only shown when the current chat service is Kobold (OAI/Claude **format**, but not service), and never if the current chat service is OAI/Claude.
- Fixes bug where deleting third party url didn't work ([3708521](https://github.com/luminai-companion/agn-ai/pull/206/commits/370852146bb6abf75ea685d22cc914408b71304c) not sure if my approach is the best)
- fix: when using third party {claude|openai} url, use kobold default preset, not {claude|openai} default preset