### PR TITLE
UX: Characters loading indicator

### DIFF
--- a/web/store/character.ts
+++ b/web/store/character.ts
@@ -53,7 +53,10 @@ export const characterStore = createStore<CharacterState>(
       const res = await data.chars.getCharacters()
       yield { loading: false }
 
-      if (res.error) toastStore.error('Failed to retrieve characters')
+      if (res.error) {
+        return toastStore.error('Failed to retrieve characters')
+      }
+
       if (res.result) {
         return { characters: { list: res.result.characters, loaded: true } }
       }


### PR DESCRIPTION
Fix infinite loop in the characters screen, calling the load endpoint every time. (You might want to push that fairly quickly)

Also include a basic loading (to be improved upon eventually).

Changed the store so it either returns loaded characters, or not, without returning that the characters is loaded first, and the characters after, avoiding a screen refresh.