### PR TITLE
feat: replace <USER> and <BOT> too, make replaces case-insensitive

### DIFF
--- a/common/image-prompt.ts
+++ b/common/image-prompt.ts
@@ -1,9 +1,7 @@
 import { AppSchema } from '../srv/db/schema'
 import { formatCharacter } from './prompt'
 import { getEncoder } from './tokenize'
-
-const BOT_REPLACE = /\{\{char\}\}/g
-const SELF_REPLACE = /\{\{user\}\}/g
+import { BOT_REPLACE, SELF_REPLACE } from './prompt'
 
 export type ImagePromptOpts = {
   user: AppSchema.User

--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -42,8 +42,9 @@ export type PromptOpts = {
   book?: AppSchema.MemoryBook
 }
 
-export const BOT_REPLACE = /\{\{char\}\}/g
-export const SELF_REPLACE = /\{\{user\}\}/g
+/** {{user}}, <user>, {{char}}, <bot>, case insensitive */
+export const BOT_REPLACE = /(\{\{char\}\}|<BOT>)/gi
+export const SELF_REPLACE = /(\{\{user\}\}|<USER>)/gi
 
 /**
  * This is only ever invoked client-side

--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -223,10 +223,8 @@ export function getPromptParts(
       .replace(/\{\{memory\}\}/gi, parts.memory || '')
       .replace(/\{\{name\}\}/gi, char.name)
       .replace(/\<BOT\>/gi, char.name)
-      .replace(/\<USER\>/gi, char.name)
+      .replace(/\<USER\>/gi, sender)
       .replace(/\{\{personality\}\}/gi, formatCharacter(char.name, chat.overrides || char.persona))
-      .replace(/\{\{char\}\}/gi, char.name)
-      .replace(/\{\{user\}\}/gi, sender)
   }
 
   parts.gaslight = gaslight
@@ -235,10 +233,8 @@ export function getPromptParts(
     .replace(/\{\{memory\}\}/gi, parts.memory || '')
     .replace(/\{\{name\}\}/gi, char.name)
     .replace(/\<BOT\>/gi, char.name)
-    .replace(/\<USER\>/gi, char.name)
+    .replace(/\<USER\>/gi, sender)
     .replace(/\{\{personality\}\}/gi, formatCharacter(char.name, chat.overrides || char.persona))
-    .replace(/\{\{char\}\}/gi, char.name)
-    .replace(/\{\{user\}\}/gi, sender)
 
   /**
    * If the gaslight does not have a sample chat placeholder, but we do have sample chat

--- a/tests/prompt.spec.ts
+++ b/tests/prompt.spec.ts
@@ -243,10 +243,12 @@ describe('Prompt building', () => {
   })
 
   it('uses the correct replaces for all instances of {{char}}, {{user}}, <BOT>, and <USER>, case insensitive', () => {
-    const input = "{{char}} loves {{user}}, {{CHAR}} hates {{USER}}, {{Char}} eats {{User}}, <BOT> drinks <USER>, <bot> boops <user>, <Bot> kicks <User>"
-    const expectedOutput = "Haruhi loves Chad, Haruhi hates Chad, Haruhi eats Chad, Haruhi drinks Chad, Haruhi boops Chad, Haruhi kicks Chad"
-    const actualOutput = input.replace(BOT_REPLACE, "Haruhi").replace(SELF_REPLACE, "Chad")
-    expect(actualOutput).to.be(expectedOutput)
+    const input =
+      '{{char}} loves {{user}}, {{CHAR}} hates {{USER}}, {{Char}} eats {{User}}, <BOT> drinks <USER>, <bot> boops <user>, <Bot> kicks <User>'
+    const expectedOutput =
+      'Haruhi loves Chad, Haruhi hates Chad, Haruhi eats Chad, Haruhi drinks Chad, Haruhi boops Chad, Haruhi kicks Chad'
+    const actualOutput = input.replace(BOT_REPLACE, 'Haruhi').replace(SELF_REPLACE, 'Chad')
+    expect(actualOutput).to.equal(expectedOutput)
   })
 })
 

--- a/tests/prompt.spec.ts
+++ b/tests/prompt.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { OPENAI_MODELS } from '../common/adapters'
-import { createPrompt } from '../common/prompt'
+import { createPrompt, BOT_REPLACE, SELF_REPLACE } from '../common/prompt'
 import { getEncoder } from '../common/tokenize'
 import { AppSchema } from '../srv/db/schema'
 import { toBook, toChar, toBotMsg, toChat, toEntry, toProfile, toUser, toUserMsg } from './util'
@@ -240,6 +240,13 @@ describe('Prompt building', () => {
         'Bot:'
       )
     )
+  })
+
+  it('uses the correct replaces for all instances of {{char}}, {{user}}, <BOT>, and <USER>, case insensitive', () => {
+    const input = "{{char}} loves {{user}}, {{CHAR}} hates {{USER}}, {{Char}} eats {{User}}, <BOT> drinks <USER>, <bot> boops <user>, <Bot> kicks <User>"
+    const expectedOutput = "Haruhi loves Chad, Haruhi hates Chad, Haruhi eats Chad, Haruhi drinks Chad, Haruhi boops Chad, Haruhi kicks Chad"
+    const actualOutput = input.replace(BOT_REPLACE, "Haruhi").replace(SELF_REPLACE, "Chad")
+    expect(actualOutput).to.be(expectedOutput)
   })
 })
 

--- a/web/pages/Chat/components/Message.tsx
+++ b/web/pages/Chat/components/Message.tsx
@@ -156,7 +156,7 @@ const SingleMessage: Component<
         <div class="flex w-full flex-row justify-between">
           <div class="flex flex-col items-start gap-1 sm:flex-row sm:items-end sm:gap-0">
             <b
-              class="text-900 mr-2 max-w-[200px] overflow-hidden text-ellipsis  whitespace-nowrap text-lg leading-none sm:max-w-[400px]"
+              class="text-900 text-md mr-2 max-w-[160px] overflow-hidden  text-ellipsis whitespace-nowrap leading-none sm:max-w-[400px] sm:text-lg"
               data-bot-name={isBot()}
               data-user-name={isUser()}
             >


### PR DESCRIPTION
- changes agnai to use the same replaces as sillylossy, to wit, {{char}}, {{user}}, <USER>, and <BOT> all case-insensitive. (Certain botmakers create bots with the Silly replaces in mind, so it is preferable to align with whatever they do.)
- changes the image prompt module to use the same replaces as the rest of the app instead of duplicated regexp definitions
- adds a unit test to check the replaces are working as expected

Silly code: https://github.com/Cohee1207/SillyTavern/blob/b180aeaae53f41db578c0927ba0cc8ae5d30c290/public/script.js#L1020

### Regex tests:
![regex test 1](https://user-images.githubusercontent.com/128472336/233626115-4ec3e8d9-2b58-4bfb-8a43-b98a56b4c5bc.png)
![regex test 2](https://user-images.githubusercontent.com/128472336/233626132-a6f1661b-cbb6-473d-858c-923285a1b275.png)

### Live test:
#### Bot defs
![1682077685](https://user-images.githubusercontent.com/128472336/233628254-b627b07e-6de8-403c-b8f3-243507d7700c.png)

#### Resulting prompt
![1682077671](https://user-images.githubusercontent.com/128472336/233628274-2f587c6b-5313-459b-accf-9d11596f1b5f.png)
