### PR TITLE
Feat: character card improvements

### DIFF
--- a/web/pages/Character/CharacterList.tsx
+++ b/web/pages/Character/CharacterList.tsx
@@ -166,7 +166,10 @@ const Characters: Component<{ type: string; filter: string; sort: string }> = (p
         </Show>
 
         <Show when={props.type !== 'list'}>
-          <div class="grid w-full grid-cols-2 flex-row flex-wrap justify-center gap-2 sm:grid-cols-6">
+          <div
+            style="grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));"
+            class="grid w-full flex-row flex-wrap justify-center gap-2"
+          >
             <For each={chars()}>
               {(char) => (
                 <Character

--- a/web/pages/Character/CharacterList.tsx
+++ b/web/pages/Character/CharacterList.tsx
@@ -151,7 +151,7 @@ const Characters: Component<{ type: string; filter: string; sort: string }> = (p
       </Show>
       <Show when={state.list.length > 0}>
         <Show when={props.type === 'list'}>
-          <div class="flex w-full flex-col gap-2">
+          <div class="flex w-full flex-col gap-2 pb-5">
             <For each={chars()}>
               {(char) => (
                 <Character
@@ -166,7 +166,7 @@ const Characters: Component<{ type: string; filter: string; sort: string }> = (p
         </Show>
 
         <Show when={props.type !== 'list'}>
-          <div class="grid w-full grid-cols-[repeat(auto-fit,minmax(105px,1fr))] flex-row flex-wrap justify-start gap-2">
+          <div class="grid w-full grid-cols-[repeat(auto-fit,minmax(105px,1fr))] flex-row flex-wrap justify-start gap-2 pb-5">
             <For each={chars()}>
               {(char) => (
                 <Character

--- a/web/pages/Character/CharacterList.tsx
+++ b/web/pages/Character/CharacterList.tsx
@@ -166,10 +166,7 @@ const Characters: Component<{ type: string; filter: string; sort: string }> = (p
         </Show>
 
         <Show when={props.type !== 'list'}>
-          <div
-            style="grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));"
-            class="grid w-full flex-row flex-wrap justify-center gap-2"
-          >
+          <div class="grid w-full grid-cols-[repeat(auto-fit,minmax(105px,1fr))] flex-row flex-wrap justify-start gap-2">
             <For each={chars()}>
               {(char) => (
                 <Character
@@ -242,44 +239,59 @@ const Character: Component<{
 
   return (
     <div class="flex flex-col items-center justify-between gap-1 rounded-md bg-[var(--bg-700)] p-1">
-      <div class="flex w-full justify-end" onClick={() => setOpts(true)}>
-        <div>
-          <Menu size={14} class="icon-button" />
-        </div>
-        <DropMenu show={opts()} close={() => setOpts(false)} horz="left" vert="down">
-          <div class="flex flex-col gap-2 p-2">
-            <Button size="sm" onClick={wrap(props.download)}>
-              Download
-            </Button>
-            <Button size="sm" onClick={() => nav(`/character/${props.char._id}/edit`)}>
-              Edit
-            </Button>
-            <Button size="sm" onClick={() => nav(`/character/create/${props.char._id}`)}>
-              Duplicate
-            </Button>
-            <Button size="sm" onClick={wrap(props.delete)}>
-              Delete
-            </Button>
-          </div>
-        </DropMenu>
+      <div class="w-full">
+        <Show when={props.char.avatar}>
+          <A
+            href={`/character/${props.char._id}/chats`}
+            class="block h-32 w-full justify-center overflow-hidden rounded-lg"
+          >
+            <img src={getAssetUrl(props.char.avatar!)} class="h-full w-full object-cover" />
+          </A>
+        </Show>
+        <Show when={!props.char.avatar}>
+          <A
+            href={`/character/${props.char._id}/chats`}
+            class="w-full items-center flex h-32 justify-center rounded-md bg-[var(--bg-700)]"
+          >
+            <VenetianMask size={24} />
+          </A>
+        </Show>
       </div>
-
-      <Show when={props.char.avatar}>
-        <A href={`/character/${props.char._id}/chats`} class="flex justify-center">
-          <img src={getAssetUrl(props.char.avatar!)} class="max-h-32 max-w-full rounded-lg" />
-        </A>
-      </Show>
-      <Show when={!props.char.avatar}>
-        <A
-          href={`/character/${props.char._id}/chats`}
-          class="flex h-32 w-full items-center justify-center rounded-md bg-[var(--bg-700)]"
-        >
-          <VenetianMask size={24} />
-        </A>
-      </Show>
-      <div class="flex w-full justify-center text-sm">
-        <div class="overflow-hidden text-ellipsis whitespace-nowrap font-bold">
+      <div class="w-full text-sm">
+        <div class="overflow-hidden text-ellipsis whitespace-nowrap px-1 font-bold">
           {props.char.name}
+        </div>
+        {/* hacky positioning shenanigans are necessary as opposed to using an
+            absolute positioning because if any of the DropMenu parent is
+            positioned, then DropMenu breaks because it relies on the nearest
+            positioned parent to be the sitewide container */}
+        <div
+          class="float-right mt-[-150px] mr-[3px] flex justify-end"
+          onClick={() => setOpts(true)}
+        >
+          <div class=" rounded-md bg-[var(--bg-500)] p-[2px]">
+            <Menu size={24} class="icon-button" color="var(--bg-100)" />
+          </div>
+          <DropMenu
+            show={opts()}
+            close={() => setOpts(false)}
+            customPosition="right-[-6px] top-[-3px]"
+          >
+            <div class="flex flex-col gap-2 p-2">
+              <Button size="sm" onClick={wrap(props.download)}>
+                Download
+              </Button>
+              <Button size="sm" onClick={() => nav(`/character/${props.char._id}/edit`)}>
+                Edit
+              </Button>
+              <Button size="sm" onClick={() => nav(`/character/create/${props.char._id}`)}>
+                Duplicate
+              </Button>
+              <Button size="sm" onClick={wrap(props.delete)}>
+                Delete
+              </Button>
+            </div>
+          </DropMenu>
         </div>
       </div>
     </div>

--- a/web/pages/Character/CharacterList.tsx
+++ b/web/pages/Character/CharacterList.tsx
@@ -251,7 +251,7 @@ const Character: Component<{
         <Show when={!props.char.avatar}>
           <A
             href={`/character/${props.char._id}/chats`}
-            class="w-full items-center flex h-32 justify-center rounded-md bg-[var(--bg-700)]"
+            class="flex h-32 w-full items-center justify-center rounded-md bg-[var(--bg-700)]"
           >
             <VenetianMask size={24} />
           </A>
@@ -266,7 +266,7 @@ const Character: Component<{
             positioned, then DropMenu breaks because it relies on the nearest
             positioned parent to be the sitewide container */}
         <div
-          class="float-right mt-[-150px] mr-[3px] flex justify-end"
+          class="float-right mt-[-149px] mr-[3px] flex justify-end"
           onClick={() => setOpts(true)}
         >
           <div class=" rounded-md bg-[var(--bg-500)] p-[2px]">

--- a/web/shared/DropMenu.tsx
+++ b/web/shared/DropMenu.tsx
@@ -45,7 +45,13 @@ export const DropMenu: Component<{
   children: any
   horz?: 'left' | 'right'
   vert?: 'up' | 'down'
+  customPosition?: string
 }> = (props) => {
+  const position = createMemo(
+    () =>
+      props.customPosition ??
+      `${props.vert === 'up' ? 'bottom-11' : ''} ${props.horz === 'left' ? 'right-0' : ''}`
+  )
   const vert = createMemo(() => (props.vert === 'up' ? 'bottom-11' : ''))
   const horz = createMemo(() => (props.horz === 'left' ? 'right-0' : ''))
 
@@ -63,7 +69,7 @@ export const DropMenu: Component<{
       </Show>
       <div class="relative text-sm">
         <Show when={props.show}>
-          <div class={`absolute ${vert()} ${horz()} z-20 w-fit rounded-md bg-[var(--bg-800)]`}>
+          <div class={`absolute ${position()} z-20 w-fit rounded-md bg-[var(--bg-800)]`}>
             {props.children}
           </div>
         </Show>


### PR DESCRIPTION
[wip_agnai_cards2-2023-04-22_14.01.12.webm](https://user-images.githubusercontent.com/128472336/233783615-e31c02c6-7f22-4498-88f7-c398fcf485a0.webm)

Character grid number of columns is now fluid.
Character grid images' aspect ratio is now fixed.
Burger menu is now larger (mobile friendly), and overlaid on top of the avatar. (Note: some positioning shenanigans were necessary because the DropMenu component relies on its parents not being positioned except the sitewide container.)
General tweaks.