### PR TITLE
fix: allow chevrons (angled brackets <>) by converting them to ‹› instead of *

### DIFF
--- a/web/pages/Chat/components/Message.tsx
+++ b/web/pages/Chat/components/Message.tsx
@@ -297,7 +297,8 @@ function parseMessage(
   return msg
     .replace(BOT_REPLACE, char.name)
     .replace(SELF_REPLACE, profile?.handle || 'You')
-    .replace(/(<|>)/g, '*')
+    .replace(/(<)/g, '‹')
+    .replace(/(>)/g, '›')
 }
 
 export type SplitMessage = AppSchema.ChatMessage & { split?: boolean; handle?: string }


### PR DESCRIPTION
This PR replaces chevrons (<>) with single guillemets (‹›) instead of stars.

In the future, deeper work should be done to:

- Fully sanitize the HTML produced by the markdown parser to eliminate XSS attacks (even without HTML tags XSS may be possible)
- Allow chevrons without replacing them, while still not rendering HTML tags, so that "code assistant"-type chatbots don't produce broken code.

This will take laying out in details our requirements (e.g. no html rendering, support single newline as well as double newline, ...) and a lot of experimenting testing out different markdown renderers. I tried briefly and then decided to stick with this incremental improvement for now.