### PR TITLE
Feat/page titles

### DIFF
--- a/common/default-preset.ts
+++ b/common/default-preset.ts
@@ -95,9 +95,9 @@ export const defaultPresets = {
     antiBond: false,
     useGaslight: false,
     gaslight: `Enter roleplay mode. {{user}} will write {{char}}'s next reply in a dialogue between {{char}} and {{user}}. Do not decide what {{char}} says or does. Use Internet roleplay style, e.g. no quotation marks, and write user actions in italic in third person like: *he jumps in excitement*. You are allowed to use markdown. Be proactive, creative, drive the plot and conversation forward. Write at least one paragraph, up to four. Always stay in character. Always keep the conversation going. (Repetition is highly discouraged)
-    Avoid writing a NSFW/Smut reply. Creatively write around it NSFW/Smut scenarios in character.
+Avoid writing a NSFW/Smut reply. Creatively write around it NSFW/Smut scenarios in character.
     
-    Description of {{char}}:
+Description of {{char}}:
 {{personality}}
 Circumstances and context of the dialogue: {{scenario}}
 Facts: {{memory}}

--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -11,6 +11,7 @@ export type PromptParts = {
   sampleChat?: string[]
   persona: string
   gaslight: string
+  ujb?: string
   post: string[]
   gaslightHasChat: boolean
   memory?: string
@@ -210,17 +211,33 @@ export function getPromptParts(
   if (memory) parts.memory = memory.prompt
 
   const gaslight = opts.settings?.gaslight || defaultPresets.openai.gaslight
+  const ujb = opts.settings?.ultimeJailbreak
 
   const sampleChat = parts.sampleChat?.join('\n') || ''
+
+  if (ujb) {
+    parts.ujb = ujb
+      .replace(/\{\{example_dialogue\}\}/gi, sampleChat)
+      .replace(/\{\{scenario\}\}/gi, parts.scenario || '')
+      .replace(/\{\{memory\}\}/gi, parts.memory || '')
+      .replace(/\{\{name\}\}/gi, char.name)
+      .replace(/\<BOT\>/gi, char.name)
+      .replace(/\<USER\>/gi, char.name)
+      .replace(/\{\{personality\}\}/gi, formatCharacter(char.name, chat.overrides || char.persona))
+      .replace(/\{\{char\}\}/gi, char.name)
+      .replace(/\{\{user\}\}/gi, sender)
+  }
+
   parts.gaslight = gaslight
-    .replace(/\{\{example_dialogue\}\}/g, sampleChat)
-    .replace(/\{\{scenario\}\}/g, parts.scenario || '')
-    .replace(/\{\{memory\}\}/g, parts.memory || '')
-    .replace(/\{\{name\}\}/g, char.name)
-    .replace(/\<BOT\>/g, char.name)
-    .replace(/\{\{personality\}\}/g, formatCharacter(char.name, chat.overrides || char.persona))
-    .replace(/\{\{char\}\}/g, char.name)
-    .replace(/\{\{user\}\}/g, sender)
+    .replace(/\{\{example_dialogue\}\}/gi, sampleChat)
+    .replace(/\{\{scenario\}\}/gi, parts.scenario || '')
+    .replace(/\{\{memory\}\}/gi, parts.memory || '')
+    .replace(/\{\{name\}\}/gi, char.name)
+    .replace(/\<BOT\>/gi, char.name)
+    .replace(/\<USER\>/gi, char.name)
+    .replace(/\{\{personality\}\}/gi, formatCharacter(char.name, chat.overrides || char.persona))
+    .replace(/\{\{char\}\}/gi, char.name)
+    .replace(/\{\{user\}\}/gi, sender)
 
   /**
    * If the gaslight does not have a sample chat placeholder, but we do have sample chat

--- a/srv/adapter/openai.ts
+++ b/srv/adapter/openai.ts
@@ -61,10 +61,9 @@ export const handleOAI: ModelAdapter = async function* (opts) {
       all.push(...lines)
     }
 
-    if (gen.ultimeJailbreak) {
-      const ujb = gen.ultimeJailbreak.replace(BOT_REPLACE, char.name).replace(SELF_REPLACE, user)
-      history.push({ role: 'system', content: ujb })
-      tokens += encoder(ujb)
+    if (parts.ujb) {
+      history.push({ role: 'system', content: parts.ujb })
+      tokens += encoder(parts.ujb)
     }
 
     if (kind === 'continue') {

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -58,8 +58,8 @@ const App: Component = () => {
               <Routes>
                 <CharacterRoutes />
                 <Route path="/chats" component={CharacterChats} />
-                <Route path="/chat" component={() => <ChatDetail />} />
-                <Route path="/chat/:id" component={() => <ChatDetail />} />
+                <Route path="/chat" component={ChatDetail} />
+                <Route path="/chat/:id" component={ChatDetail} />
                 <Route path="/" component={CharacterList} />
                 <Route path="/info" component={HomePage} />
                 <Route path="/changelog" component={ChangeLog} />

--- a/web/Navigation.tsx
+++ b/web/Navigation.tsx
@@ -100,7 +100,7 @@ const UserNavigation: Component = () => {
       </Show>
       <Item href="/info">
         <Info />
-        Infomation
+        Information
       </Item>
     </>
   )

--- a/web/pages/Admin/Metrics.tsx
+++ b/web/pages/Admin/Metrics.tsx
@@ -3,9 +3,11 @@ import { Component, createEffect } from 'solid-js'
 import Button from '../../shared/Button'
 import { FormLabel } from '../../shared/FormLabel'
 import PageHeader from '../../shared/PageHeader'
+import { setComponentPageTitle } from '../../shared/util'
 import { adminStore } from '../../store'
 
 const MetricsPage: Component = () => {
+  setComponentPageTitle('Metrics')
   const state = adminStore()
 
   createEffect(() => {

--- a/web/pages/Admin/UsersPage.tsx
+++ b/web/pages/Admin/UsersPage.tsx
@@ -4,10 +4,11 @@ import Button from '../../shared/Button'
 import Modal from '../../shared/Modal'
 import PageHeader from '../../shared/PageHeader'
 import TextInput from '../../shared/TextInput'
-import { getAssetUrl, getStrictForm } from '../../shared/util'
+import { getAssetUrl, getStrictForm, setComponentPageTitle } from '../../shared/util'
 import { adminStore } from '../../store'
 
 const UsersPage: Component = () => {
+  setComponentPageTitle('Users')
   const [pw, setPw] = createSignal('')
   const state = adminStore()
   const [info, setInfo] = createSignal<{ name: string; id: string }>()

--- a/web/pages/Character/CharacterList.tsx
+++ b/web/pages/Character/CharacterList.tsx
@@ -20,7 +20,7 @@ import { A, useNavigate } from '@solidjs/router'
 import AvatarIcon from '../../shared/AvatarIcon'
 import ImportCharacterModal from '../Character/ImportCharacter'
 import DeleteCharacterModal from '../Character/DeleteCharacter'
-import { getAssetUrl } from '../../shared/util'
+import { getAssetUrl, setComponentPageTitle } from '../../shared/util'
 import { DropMenu } from '../../shared/DropMenu'
 import Button from '../../shared/Button'
 import Modal from '../../shared/Modal'
@@ -30,6 +30,7 @@ import Loading from '../../shared/Loading'
 const CACHE_KEY = 'agnai-charlist-cache'
 
 const CharacterList: Component = () => {
+  setComponentPageTitle('Characters')
   const chats = chatStore()
 
   const cached = getListCache()

--- a/web/pages/Character/ChatList.tsx
+++ b/web/pages/Character/ChatList.tsx
@@ -5,7 +5,7 @@ import PageHeader from '../../shared/PageHeader'
 import { Edit, Import, Menu, Plus, Trash } from 'lucide-solid'
 import CreateChatModal from './CreateChat'
 import ImportChatModal from './ImportChat'
-import { toDuration, toEntityMap, toMap } from '../../shared/util'
+import { setComponentPageTitle, toDuration, toEntityMap, toMap } from '../../shared/util'
 import { ConfirmModal } from '../../shared/Modal'
 import AvatarIcon from '../../shared/AvatarIcon'
 import { DropMenu } from '../../shared/DropMenu'
@@ -19,6 +19,13 @@ const CACHE_KEY = 'agnai-chatlist-cache'
 const CharacterChats: Component = () => {
   const params = useParams()
   const cache = getListCache()
+  const chars = characterStore((s) => ({
+    map: toMap(s.characters.list),
+    list: s.characters.list,
+    loaded: s.characters.loaded,
+  }))
+  const charName = chars.map[params.id]?.name
+  setComponentPageTitle(charName ? `${charName} chat list` : 'Chat list')
 
   const nav = useNavigate()
   const [search, setSearch] = createSignal('')
@@ -44,12 +51,6 @@ const CharacterChats: Component = () => {
 
     return { list }
   })
-
-  const chars = characterStore((s) => ({
-    map: toMap(s.characters.list),
-    list: s.characters.list,
-    loaded: s.characters.loaded,
-  }))
 
   const chats = createMemo(() => {
     const id = charId()

--- a/web/pages/Character/CreateCharacter.tsx
+++ b/web/pages/Character/CreateCharacter.tsx
@@ -5,7 +5,7 @@ import PageHeader from '../../shared/PageHeader'
 import TextInput from '../../shared/TextInput'
 import { FormLabel } from '../../shared/FormLabel'
 import RadioGroup from '../../shared/RadioGroup'
-import { getStrictForm } from '../../shared/util'
+import { getStrictForm, setComponentPageTitle } from '../../shared/util'
 import FileInput, { FileInputResult } from '../../shared/FileInput'
 import { characterStore } from '../../store'
 import { useNavigate, useParams } from '@solidjs/router'
@@ -23,6 +23,9 @@ const options = [
 
 const CreateCharacter: Component = () => {
   const params = useParams<{ editId?: string; duplicateId?: string }>()
+  setComponentPageTitle(
+    params.editId ? 'Edit character' : params.duplicateId ? 'Copy character' : 'Create character'
+  )
   const [image, setImage] = createSignal<string | undefined>()
 
   const srcId = params.editId || params.duplicateId || ''

--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -11,13 +11,13 @@ import {
 import ChatExport from './ChatExport'
 import { Component, createEffect, createMemo, createSignal, For, JSX, Show } from 'solid-js'
 import { ADAPTER_LABELS } from '../../../common/adapters'
-import { getAdapter } from '../../../common/prompt'
+import { getAdapter, getChatPreset } from '../../../common/prompt'
 import Button from '../../shared/Button'
 import IsVisible from '../../shared/IsVisible'
 import Modal from '../../shared/Modal'
 import TextInput from '../../shared/TextInput'
 import { getRootRgb, getStrictForm, setComponentPageTitle } from '../../shared/util'
-import { chatStore, settingStore, UISettings as UI, userStore } from '../../store'
+import { chatStore, presetStore, settingStore, UISettings as UI, userStore } from '../../store'
 import { msgStore } from '../../store'
 import { ChatGenSettingsModal } from './ChatGenSettings'
 import ChatSettingsModal from './ChatSettings'
@@ -42,6 +42,7 @@ const ChatDetail: Component = () => {
   const params = useParams()
   const nav = useNavigate()
   const user = userStore()
+  const presets = presetStore()
   const cfg = settingStore()
   const chats = chatStore((s) => ({ ...s.active, lastId: s.lastChatId, members: s.chatProfiles }))
   const msgs = msgStore((s) => ({
@@ -50,6 +51,7 @@ const ChatDetail: Component = () => {
     waiting: s.waiting,
     retries: s.retries,
   }))
+
   const [screenshotInProgress, setScreenshotInProgress] = createSignal(false)
   createEffect(() => {
     const charName = chats.char?.name
@@ -111,11 +113,14 @@ const ChatDetail: Component = () => {
   }
 
   const adapter = createMemo(() => {
-    if (!chats.chat || !user.user) return ''
+    if (!chats.chat?.adapter || !user.user) return ''
     if (chats.chat.userId !== user.user._id) return ''
 
-    const { adapter, preset, isThirdParty } = getAdapter(chats.chat!, user.user!)
-    const label = `${ADAPTER_LABELS[adapter]}${isThirdParty ? ' (3rd party)' : ''} - ${preset}`
+    const { adapter, preset: presetType, isThirdParty } = getAdapter(chats.chat!, user.user!)
+    const preset = getChatPreset(chats.chat, user.user!, presets.presets)
+    const label = `${ADAPTER_LABELS[adapter]}${isThirdParty ? ' (3rd party)' : ''} - ${
+      'name' in preset ? preset.name : presetType
+    }`
     return label
   })
 

--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -16,7 +16,7 @@ import Button from '../../shared/Button'
 import IsVisible from '../../shared/IsVisible'
 import Modal from '../../shared/Modal'
 import TextInput from '../../shared/TextInput'
-import { getRootRgb, getStrictForm } from '../../shared/util'
+import { getRootRgb, getStrictForm, setComponentPageTitle } from '../../shared/util'
 import { chatStore, settingStore, UISettings as UI, userStore } from '../../store'
 import { msgStore } from '../../store'
 import { ChatGenSettingsModal } from './ChatGenSettings'
@@ -38,6 +38,7 @@ import { ImageModal } from './ImageModal'
 const EDITING_KEY = 'chat-detail-settings'
 
 const ChatDetail: Component = () => {
+  const { updateTitle } = setComponentPageTitle('Chat')
   const params = useParams()
   const nav = useNavigate()
   const user = userStore()
@@ -50,6 +51,10 @@ const ChatDetail: Component = () => {
     retries: s.retries,
   }))
   const [screenshotInProgress, setScreenshotInProgress] = createSignal(false)
+  createEffect(() => {
+    const charName = chats.char?.name
+    updateTitle(charName ? `Chat with ${charName}` : 'Chat')
+  })
 
   const retries = createMemo(() => {
     const last = msgs.msgs.slice(-1)[0]

--- a/web/pages/GenerationPresets/PresetList.tsx
+++ b/web/pages/GenerationPresets/PresetList.tsx
@@ -6,8 +6,10 @@ import { ConfirmModal } from '../../shared/Modal'
 import PageHeader from '../../shared/PageHeader'
 import { defaultPresets } from '../../../common/presets'
 import { presetStore } from '../../store'
+import { setComponentPageTitle } from '../../shared/util'
 
 const PresetList: Component = () => {
+  setComponentPageTitle('Presets')
   const nav = useNavigate()
   const state = presetStore()
   const defaults = Object.entries(defaultPresets).map(([name, cfg]) => ({

--- a/web/pages/GenerationPresets/index.tsx
+++ b/web/pages/GenerationPresets/index.tsx
@@ -9,10 +9,11 @@ import GenerationSettings from '../../shared/GenerationSettings'
 import Modal, { ConfirmModal } from '../../shared/Modal'
 import PageHeader from '../../shared/PageHeader'
 import TextInput from '../../shared/TextInput'
-import { getStrictForm } from '../../shared/util'
+import { getStrictForm, setComponentPageTitle } from '../../shared/util'
 import { presetStore } from '../../store'
 
 export const GenerationPresetsPage: Component = () => {
+  const { updateTitle } = setComponentPageTitle('Preset')
   let ref: any
 
   const params = useParams()
@@ -35,6 +36,12 @@ export const GenerationPresetsPage: Component = () => {
 
   createEffect(async () => {
     if (params.id === 'new') {
+      const copySource = query.preset
+      if (copySource) {
+        updateTitle(`Copy preset ${copySource}`)
+      } else {
+        updateTitle(`Create preset`)
+      }
       setEditing()
       await Promise.resolve()
       const template = isDefaultPreset(query.preset)
@@ -70,6 +77,9 @@ export const GenerationPresetsPage: Component = () => {
       await Promise.resolve()
       const preset = state.presets.find((p) => p._id === params.id)
       setEditing(preset)
+    }
+    if (params.id && preset) {
+      updateTitle(`Edit preset ${preset.name}`)
     }
   })
 

--- a/web/pages/Home/ChangeLog.tsx
+++ b/web/pages/Home/ChangeLog.tsx
@@ -1,6 +1,7 @@
 import { Component } from 'solid-js'
 import PageHeader from '../../shared/PageHeader'
 import { markdown } from '../../shared/markdown'
+import { setComponentPageTitle } from '../../shared/util'
 
 const text = `
 # Change Log
@@ -11,6 +12,7 @@ _21 Apr 2023_
 `
 
 const ChangeLog: Component = () => {
+  setComponentPageTitle('Changelog')
   return (
     <>
       <PageHeader title="Change Log" />

--- a/web/pages/Home/index.tsx
+++ b/web/pages/Home/index.tsx
@@ -1,6 +1,6 @@
 import { Component } from 'solid-js'
 import PageHeader from '../../shared/PageHeader'
-import { adaptersToOptions } from '../../shared/util'
+import { adaptersToOptions, setComponentPageTitle } from '../../shared/util'
 import { settingStore } from '../../store'
 import { markdown } from '../../shared/markdown'
 import { A } from '@solidjs/router'
@@ -50,6 +50,7 @@ You can provide your API key and choose between Euterpe and Krake in the setting
 `
 
 const HomePage: Component = () => {
+  setComponentPageTitle('Information')
   const cfg = settingStore((cfg) => ({ adapters: adaptersToOptions(cfg.config.adapters) }))
   return (
     <div>

--- a/web/pages/Invite/InvitesPage.tsx
+++ b/web/pages/Invite/InvitesPage.tsx
@@ -1,11 +1,12 @@
 import { Check, X } from 'lucide-solid'
 import { Component, createEffect, For, Show } from 'solid-js'
 import PageHeader from '../../shared/PageHeader'
-import { toDuration } from '../../shared/util'
+import { setComponentPageTitle, toDuration } from '../../shared/util'
 import { inviteStore } from '../../store'
 import { useNavigate } from '@solidjs/router'
 
 export const InvitesPage: Component = () => {
+  setComponentPageTitle('Invites')
   const state = inviteStore()
   const nav = useNavigate()
 

--- a/web/pages/Login/index.tsx
+++ b/web/pages/Login/index.tsx
@@ -4,11 +4,12 @@ import Alert from '../../shared/Alert'
 import Divider from '../../shared/Divider'
 import PageHeader from '../../shared/PageHeader'
 import { toastStore, userStore } from '../../store'
-import { getStrictForm } from '../../shared/util'
+import { getStrictForm, setComponentPageTitle } from '../../shared/util'
 import TextInput from '../../shared/TextInput'
 import Button from '../../shared/Button'
 
 const LoginPage: Component = () => {
+  setComponentPageTitle('Login')
   const store = userStore()
   const [register, setRegister] = createSignal(false)
 

--- a/web/pages/Memory/EditMemory.tsx
+++ b/web/pages/Memory/EditMemory.tsx
@@ -9,7 +9,7 @@ import { FormLabel } from '../../shared/FormLabel'
 import PageHeader from '../../shared/PageHeader'
 import TextInput from '../../shared/TextInput'
 import { Toggle } from '../../shared/Toggle'
-import { getFormEntries, getStrictForm } from '../../shared/util'
+import { getFormEntries, getStrictForm, setComponentPageTitle } from '../../shared/util'
 import { memoryStore } from '../../store'
 
 const newBook: AppSchema.MemoryBook = {
@@ -102,6 +102,7 @@ const EditMemoryForm: Component<{ book: AppSchema.MemoryBook; hideSave?: boolean
 export default EditMemoryForm
 
 export const EditMemoryPage = () => {
+  const { updateTitle } = setComponentPageTitle('Memory book')
   let ref: any
   const nav = useNavigate()
   const params = useParams()
@@ -110,12 +111,14 @@ export const EditMemoryPage = () => {
 
   createEffect(() => {
     if (params.id === 'new') {
+      updateTitle('Create memory book')
       setEditing({ ...newBook, entries: [{ ...emptyEntry, name: 'New Entry' }] })
       return
     }
 
     const match = state.books.list.find((m) => m._id === params.id)
     if (match) {
+      updateTitle(`Edit ${match.name}`)
       setEditing(match)
     }
   })
@@ -153,7 +156,7 @@ export const EditMemoryPage = () => {
               <div class="text-lg font-bold">Defintitons</div>
               <FormLabel
                 fieldName="priorty"
-                label="Priorty"
+                label="Priority"
                 helperText="When deciding which entries to INCLUDE in the prompt, the higher the priority entries win."
               />
 

--- a/web/pages/Memory/index.tsx
+++ b/web/pages/Memory/index.tsx
@@ -7,9 +7,11 @@ import Button from '../../shared/Button'
 import FileInput, { FileInputResult, getFileAsString } from '../../shared/FileInput'
 import Modal from '../../shared/Modal'
 import PageHeader from '../../shared/PageHeader'
+import { setComponentPageTitle } from '../../shared/util'
 import { memoryStore, toastStore } from '../../store'
 
 const MemoryPage: Component = () => {
+  setComponentPageTitle('Memory')
   const state = memoryStore()
   const [showImport, setImport] = createSignal(false)
 

--- a/web/pages/Profile/index.tsx
+++ b/web/pages/Profile/index.tsx
@@ -6,10 +6,11 @@ import FileInput, { FileInputResult } from '../../shared/FileInput'
 import Modal from '../../shared/Modal'
 import PageHeader from '../../shared/PageHeader'
 import TextInput from '../../shared/TextInput'
-import { getStrictForm } from '../../shared/util'
+import { getStrictForm, setComponentPageTitle } from '../../shared/util'
 import { toastStore, userStore } from '../../store'
 
 const ProfilePage: Component = () => {
+  setComponentPageTitle('My profile')
   const state = userStore()
   const [pass, setPass] = createSignal(false)
   const [avatar, setAvatar] = createSignal<File | undefined>()

--- a/web/pages/Settings/index.tsx
+++ b/web/pages/Settings/index.tsx
@@ -2,7 +2,7 @@ import { Component, createMemo, createSignal } from 'solid-js'
 import { AlertTriangle, Save } from 'lucide-solid'
 import Button from '../../shared/Button'
 import PageHeader from '../../shared/PageHeader'
-import { getFormEntries, getStrictForm } from '../../shared/util'
+import { getFormEntries, getStrictForm, setComponentPageTitle } from '../../shared/util'
 import { CHAT_ADAPTERS, ChatAdapter, AIAdapter } from '../../../common/adapters'
 import { userStore } from '../../store'
 import { AppSchema } from '../../../srv/db/schema'
@@ -26,6 +26,7 @@ type DefaultAdapter = Exclude<ChatAdapter, 'default'>
 const adapterOptions = CHAT_ADAPTERS.filter((adp) => adp !== 'default') as DefaultAdapter[]
 
 const Settings: Component = () => {
+  setComponentPageTitle('Settings')
   const state = userStore()
 
   const [tab, setTab] = createSignal(0)

--- a/web/shared/util.ts
+++ b/web/shared/util.ts
@@ -277,8 +277,14 @@ export const setComponentPageTitle = (newTitle: string) => {
       document.title = 'Agnaistic'
     })
   })
-}
 
-export const updateComponentPageTitle = (newTitle: string) => {
-  document.title = `${newTitle} - Agnaistic`
+  const updateTitle = (newTitle: string) => {
+    document.title = `${newTitle} - Agnaistic`
+  }
+
+  // setComponentPageTitle must be called in order for consumers to
+  // obtain updateComponentPageTitle, to prevent consumers from calling
+  // updateComponentPageTitle on its own which would change the title without
+  // the onCleanup hook.
+  return { updateTitle }
 }

--- a/web/shared/util.ts
+++ b/web/shared/util.ts
@@ -2,6 +2,7 @@ import { UnwrapBody, assertValid } from 'frisker'
 import { ADAPTER_LABELS, AIAdapter } from '../../common/adapters'
 import { isLoggedIn } from '../store/api'
 import { Option } from './Select'
+import { createEffect, onCleanup } from 'solid-js'
 
 type FormRef = {
   [key: string]:
@@ -266,4 +267,18 @@ export function toMap<T extends { _id: string }>(list: T[]): Record<string, T> {
 export function sort<T>(prop: keyof T, dir?: 'asc' | 'desc') {
   const mod = dir === 'asc' ? 1 : -1
   return (l: T, r: T) => (l[prop] > r[prop] ? mod : l[prop] === r[prop] ? 0 : -mod)
+}
+
+export const setComponentPageTitle = (newTitle: string) => {
+  createEffect(() => {
+    document.title = `${newTitle} - Agnaistic`
+
+    onCleanup(() => {
+      document.title = 'Agnaistic'
+    })
+  })
+}
+
+export const updateComponentPageTitle = (newTitle: string) => {
+  document.title = `${newTitle} - Agnaistic`
 }

--- a/web/store/chat.ts
+++ b/web/store/chat.ts
@@ -140,7 +140,7 @@ export const chatStore = createStore<ChatState>('chat', {
         onSuccess?.()
         toastStore.success('Updated chat settings')
 
-        if (all) {
+        if (all?.chats) {
           yield {
             all: {
               chars: all.chars,


### PR DESCRIPTION
This commit adds page titles to every route.

Implementation note: there's no existing way to do this declaratively in client-rendered solidjs. Server-side-rendered sites can use @solidjs/meta but not us. Therefore the canonical way to do it for now is imperatively mutating document.title inside a createEffect.

I've created a 'hook' (unsure if correct solidjs terminology) called setComponentPageTitle. Using onCleanup, it ensures exiting the page resets the title to 'Agnaistic', just in case the user navigates to a component which has no title. This hook returns the function `updateTitle`, which may be needed to dynamically update the title. It's a simple `document.title` mutation, but having it returned by setComponentPageTitle protects devs against setting the title without the onCleanup mechanism.

Also: minor typo fixes.