### PR TITLE
feat: various memory book improvements/qol

### DIFF
--- a/web/pages/Chat/components/MemoryModal.tsx
+++ b/web/pages/Chat/components/MemoryModal.tsx
@@ -3,11 +3,11 @@ import { Component, createMemo, createSignal, onMount, Show } from 'solid-js'
 import { AppSchema } from '../../../../srv/db/schema'
 import Button from '../../../shared/Button'
 import Divider from '../../../shared/Divider'
-import Select from '../../../shared/Select'
+import Select, { Option } from '../../../shared/Select'
 import Modal from '../../../shared/Modal'
 import { chatStore } from '../../../store'
 import { memoryStore } from '../../../store'
-import EditMemoryForm, { getBookUpdate } from '../../Memory/EditMemory'
+import EditMemoryForm, { getBookUpdate, EntrySort } from '../../Memory/EditMemory'
 
 const ChatMemoryModal: Component<{
   chat: AppSchema.Chat
@@ -21,6 +21,12 @@ const ChatMemoryModal: Component<{
 
   const [id, setId] = createSignal(props.chat.memoryId || '')
   const [book, setBook] = createSignal<AppSchema.MemoryBook>()
+  const [entrySort, setEntrySort] = createSignal<EntrySort>('creationDate')
+  const updateEntrySort = (item: Option<string>) => {
+    if (item.value === 'creationDate' || item.value === 'alpha') {
+      setEntrySort(item.value)
+    }
+  }
 
   const changeBook = async (id: string) => {
     setId(id)
@@ -90,7 +96,12 @@ const ChatMemoryModal: Component<{
 
         <Show when={book()}>
           <div class="text-sm">
-            <EditMemoryForm hideSave book={book()!} />
+            <EditMemoryForm
+              hideSave
+              book={book()!}
+              entrySort={entrySort()}
+              updateEntrySort={updateEntrySort}
+            />
           </div>
         </Show>
       </div>

--- a/web/pages/Memory/EditMemory.tsx
+++ b/web/pages/Memory/EditMemory.tsx
@@ -114,7 +114,12 @@ const EditMemoryForm: Component<{
           placeholder="(Optional) A description for your memory book"
         />
         <Divider />
-        <div class="text-lg font-bold">Entries</div>
+        <div class="sticky top-0 z-10 flex items-center justify-between bg-[var(--bg-900)] py-2">
+          <div class="text-lg font-bold">Entries</div>
+          <Button onClick={addEntry}>
+            <Plus /> Entry
+          </Button>
+        </div>
         <div class="flex items-center">
           <div class="max-w-[200px]">
             <TextInput

--- a/web/pages/Memory/EditMemory.tsx
+++ b/web/pages/Memory/EditMemory.tsx
@@ -10,7 +10,12 @@ import PageHeader from '../../shared/PageHeader'
 import Select, { Option } from '../../shared/Select'
 import TextInput from '../../shared/TextInput'
 import { Toggle } from '../../shared/Toggle'
-import { alphaCaseInsensitiveSort, getFormEntries, getStrictForm, setComponentPageTitle } from '../../shared/util'
+import {
+  alphaCaseInsensitiveSort,
+  getFormEntries,
+  getStrictForm,
+  setComponentPageTitle,
+} from '../../shared/util'
 import { memoryStore } from '../../store'
 
 const newBook: AppSchema.MemoryBook = {

--- a/web/pages/Memory/EditMemory.tsx
+++ b/web/pages/Memory/EditMemory.tsx
@@ -37,7 +37,7 @@ const missingFieldsInEntry = (entry: AppSchema.MemoryEntry): (keyof AppSchema.Me
   ...(entry.entry === '' ? ['entry' as const] : []),
 ]
 
-type EntrySort = 'creationDate' | 'alpha'
+export type EntrySort = 'creationDate' | 'alpha'
 
 const entrySortItems = [
   { label: 'By creation date', value: 'creationDate' },

--- a/web/shared/Modal.tsx
+++ b/web/shared/Modal.tsx
@@ -52,7 +52,7 @@ const Modal: Component<Props> = (props) => {
 
             {/* 132px is the height of the title + footer*/}
             <div
-              class={`max-h-[calc(80vh-132px)] sm:max-h-[calc(90vh-132px)] ${minHeight()} overflow-y-auto p-4 text-lg`}
+              class={`max-h-[calc(80vh-132px)] sm:max-h-[calc(90vh-132px)] ${minHeight()} overflow-y-auto p-4 pt-0 text-lg`}
             >
               {props.children}
             </div>

--- a/web/shared/PageHeader.tsx
+++ b/web/shared/PageHeader.tsx
@@ -1,20 +1,30 @@
-import { Component, JSX, Show } from 'solid-js'
+import { Component, JSX, Show, createMemo } from 'solid-js'
 import Divider from './Divider'
 
-type Props = { title: string | JSX.Element; subtitle?: string | JSX.Element; noDivider?: boolean }
+type Props = {
+  title: string | JSX.Element
+  subtitle?: string | JSX.Element
+  noDivider?: boolean
+  sticky?: boolean
+}
 
-const PageHeader: Component<Props> = (props) => (
-  <>
-    <h1 class="text-900 justify-center text-4xl sm:flex sm:w-full sm:justify-start">
-      {props.title}
-    </h1>
-    <Show when={!!props.subtitle}>
-      <p class="text-[var(--text-700)]">{props.subtitle}</p>
-    </Show>
-    <Show when={!props.noDivider}>
-      <Divider />
-    </Show>
-  </>
-)
+const PageHeader: Component<Props> = (props) => {
+  const mod = createMemo(() => (props.sticky ? `sticky top-0 py-2` : ''))
+  return (
+    <>
+      <div class={`${mod()} bg-[var(--bg-900)]`}>
+        <h1 class={'text-900 justify-center text-4xl sm:flex sm:w-full sm:justify-start'}>
+          {props.title}
+        </h1>
+      </div>
+      <Show when={!!props.subtitle}>
+        <p class="text-[var(--text-700)]">{props.subtitle}</p>
+      </Show>
+      <Show when={!props.noDivider}>
+        <Divider />
+      </Show>
+    </>
+  )
+}
 
 export default PageHeader

--- a/web/shared/util.ts
+++ b/web/shared/util.ts
@@ -258,6 +258,21 @@ export function toMap<T extends { _id: string }>(list: T[]): Record<string, T> {
   return map
 }
 
+export const alphaCaseInsensitiveSort = (
+  a: string,
+  b: string,
+  direction: 'asc' | 'desc' = 'asc'
+) => {
+  const modifier = direction === 'asc' ? 1 : -1
+  if (a.toLowerCase() < b.toLowerCase()) {
+    return -1 * modifier
+  } else if (a.toLowerCase() > b.toLowerCase()) {
+    return 1 * modifier
+  } else {
+    return 0
+  }
+}
+
 /**
  * Ascending by default
  * @param prop


### PR DESCRIPTION
closes #233 

- Add option to sort entries alphabetically
- Move "+ Entry" button to the bottom of the entry list (when the entry list is very long it doesn't make sense to have to scroll up to add an entry and then scroll back down to see it)
- when adding a new entry, it is unfolded by default, since you ALWAYS want to fill in its fields. this sort of also addresses a bug where if you added an entry then tried saving the memory book without filling in the entry, a runtime exception would be thrown and saving would fail silently
- some typo fixes

KNOWN ISSUE:
- When adding a new entry, it will remain be at the bottom of the entry list even in alphabetical mode, until the page is refreshed. This would take some major refactoring to fix, and is a fairly small issue, I think it deserves its own separate ticket so we can ship this.

### Demo

https://user-images.githubusercontent.com/128472336/233802099-776fa5e5-0fbe-46d7-ab62-fe5b4a02e551.mp4



