### PR TITLE
bugfix: dont use alternate baseurl when service is not set to kobold

### DIFF
--- a/srv/adapter/claude.ts
+++ b/srv/adapter/claude.ts
@@ -14,8 +14,8 @@ const baseUrl = `https://api.anthropic.com/v1/complete`
 const encoder = getEncoder('openai', OPENAI_MODELS.Turbo)
 
 export const handleClaude: ModelAdapter = async function* (opts) {
-  const { char, members, user, settings, log, guest, gen, sender } = opts
-  const base = getBaseUrl(user)
+  const { char, members, user, settings, log, guest, gen, sender, isThirdParty } = opts
+  const base = getBaseUrl(user, isThirdParty)
   if (!user.claudeApiKey && !base.changed) {
     yield { error: `Claude request failed: Claude API key not set. Check your settings.` }
     return
@@ -84,8 +84,8 @@ export const handleClaude: ModelAdapter = async function* (opts) {
   }
 }
 
-function getBaseUrl(user: AppSchema.User) {
-  if (user.thirdPartyFormat === 'claude' && user.koboldUrl) {
+function getBaseUrl(user: AppSchema.User, isThirdParty?: boolean) {
+  if (isThirdParty && user.thirdPartyFormat === 'claude' && user.koboldUrl) {
     return { url: user.koboldUrl, changed: true }
   }
 

--- a/srv/adapter/generate.ts
+++ b/srv/adapter/generate.ts
@@ -69,7 +69,7 @@ export async function createTextStreamV2(
     opts.char = entities.char
   }
 
-  const { adapter } = getAdapter(opts.chat, opts.user)
+  const { adapter, isThirdParty } = getAdapter(opts.chat, opts.user)
   const handler = handlers[adapter]
 
   const prompt = createPromptWithParts(opts, opts.parts, opts.lines)
@@ -90,6 +90,7 @@ export async function createTextStreamV2(
     user: opts.user,
     guest: guestSocketId,
     lines: opts.lines,
+    isThirdParty,
   })
 
   return { stream, adapter }

--- a/srv/adapter/openai.ts
+++ b/srv/adapter/openai.ts
@@ -22,9 +22,22 @@ const CHAT_MODELS: Record<string, boolean> = {
 }
 
 export const handleOAI: ModelAdapter = async function* (opts) {
-  const { char, members, user, prompt, settings, sender, log, guest, lines, parts, gen, kind } =
-    opts
-  const base = getBaseUrl(user)
+  const {
+    char,
+    members,
+    user,
+    prompt,
+    settings,
+    sender,
+    log,
+    guest,
+    lines,
+    parts,
+    gen,
+    kind,
+    isThirdParty,
+  } = opts
+  const base = getBaseUrl(user, isThirdParty)
   if (!user.oaiKey && !base.changed) {
     yield { error: `OpenAI request failed: Not OpenAI API key not set. Check your settings.` }
     return
@@ -163,8 +176,8 @@ export const handleOAI: ModelAdapter = async function* (opts) {
   }
 }
 
-function getBaseUrl(user: AppSchema.User) {
-  if (user.thirdPartyFormat === 'openai' && user.koboldUrl) {
+function getBaseUrl(user: AppSchema.User, isThirdParty?: boolean) {
+  if (isThirdParty && user.thirdPartyFormat === 'openai' && user.koboldUrl) {
     return { url: user.koboldUrl, changed: true }
   }
 

--- a/srv/adapter/type.ts
+++ b/srv/adapter/type.ts
@@ -42,6 +42,7 @@ export type AdapterProps = {
   settings: any
   guest?: string
   log: AppLog
+  isThirdParty?: boolean
 }
 
 export type ModelAdapter = (opts: AdapterProps) => AsyncGenerator<string | { error: any }>


### PR DESCRIPTION
This fixes a logic error where third party backend URLs were being used for openai/claude even if the selected service was not kobold