### PR TITLE
fix: message name alignment

### DIFF
--- a/web/pages/Chat/components/Message.tsx
+++ b/web/pages/Chat/components/Message.tsx
@@ -156,7 +156,9 @@ const SingleMessage: Component<
         <div class="flex w-full flex-row justify-between">
           <div class="flex flex-col items-start gap-1 sm:flex-row sm:items-end sm:gap-0">
             <b
-              class="text-900 text-md mr-2 max-w-[160px] overflow-hidden  text-ellipsis whitespace-nowrap leading-none sm:max-w-[400px] sm:text-lg"
+              class="text-900 text-md mr-2 max-w-[160px] overflow-hidden  text-ellipsis whitespace-nowrap sm:max-w-[400px] sm:text-lg"
+              // Necessary to override text-md and text-lg's line height, for proper alignment
+              style="line-height: 1;"
               data-bot-name={isBot()}
               data-user-name={isUser()}
             >


### PR DESCRIPTION
## before
![1682249383](https://user-images.githubusercontent.com/128472336/233837528-832e7c1f-8020-4103-90b5-14d6578296ec.png)

## after
![1682249362](https://user-images.githubusercontent.com/128472336/233837536-0649428b-685a-4a46-9263-b8d8eb7a98ec.png)
