### PR TITLE
Add extensions for vscode to recommend

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+	"recommendations": [
+		"esbenp.prettier-vscode",
+		"tailwindlabs.tailwindcss",
+	]
+}


### PR DESCRIPTION
Two extensions are recommended in the README. I believe it'd be better to also add them to the vscode config directory, for it to be recommended by vscode itself to anyone accessing the codebase.