### PR TITLE
feat: support third-party backend passwords

### DIFF
--- a/common/dummy.ts
+++ b/common/dummy.ts
@@ -45,6 +45,7 @@ export function toUser(name: string): AppSchema.User {
     kind: 'user',
     koboldUrl: '',
     thirdPartyFormat: 'kobold',
+    thirdPartyPassword: '',
     luminaiUrl: '',
     novelApiKey: '',
     novelModel: NOVEL_MODELS.krake,

--- a/srv/adapter/claude.ts
+++ b/srv/adapter/claude.ts
@@ -41,12 +41,15 @@ export const handleClaude: ModelAdapter = async function* (opts) {
     'Content-Type': 'application/json',
   }
 
-  const mustUseThirdPartyPassword = base.changed && isThirdParty && user.thirdPartyPassword
-  const potentiallyEncryptedKey = mustUseThirdPartyPassword
+  const useThirdPartyPassword = base.changed && isThirdParty && user.thirdPartyPassword
+  const apiKey = useThirdPartyPassword
     ? user.thirdPartyPassword
-    : user.claudeApiKey
-  const key = !!guest ? potentiallyEncryptedKey : decryptText(potentiallyEncryptedKey!)
-  if (!base.changed) {
+    : !isThirdParty
+    ? user.claudeApiKey
+    : null
+
+  const key = !!guest ? apiKey : apiKey ? decryptText(apiKey!) : null
+  if (key) {
     headers['x-api-key'] = key
   }
 

--- a/srv/adapter/claude.ts
+++ b/srv/adapter/claude.ts
@@ -41,8 +41,13 @@ export const handleClaude: ModelAdapter = async function* (opts) {
     'Content-Type': 'application/json',
   }
 
+  const mustUseThirdPartyPassword = base.changed && isThirdParty && user.thirdPartyPassword
+  const potentiallyEncryptedKey = mustUseThirdPartyPassword
+    ? user.thirdPartyPassword
+    : user.claudeApiKey
+  const key = !!guest ? potentiallyEncryptedKey : decryptText(potentiallyEncryptedKey!)
   if (!base.changed) {
-    headers['x-api-key'] = !!guest ? user.claudeApiKey : decryptText(user.claudeApiKey!)
+    headers['x-api-key'] = key
   }
 
   log.debug(requestBody, 'Claude payload')

--- a/srv/adapter/openai.ts
+++ b/srv/adapter/openai.ts
@@ -117,15 +117,19 @@ export const handleOAI: ModelAdapter = async function* (opts) {
 
   if (gen.antiBond) body.logit_bias = { 3938: -50, 11049: -50, 64186: -50, 3717: -25 }
 
-  const mustUseThirdPartyPassword = base.changed && isThirdParty && user.thirdPartyPassword
-  const key = mustUseThirdPartyPassword ? user.thirdPartyPassword : user.oaiKey
-  const bearer = !!guest ? `Bearer ${key}` : `Bearer ${decryptText(key)}`
+  const useThirdPartyPassword = base.changed && isThirdParty && user.thirdPartyPassword
+  const apiKey = useThirdPartyPassword
+    ? user.thirdPartyPassword
+    : !isThirdParty
+    ? user.oaiKey
+    : null
+  const bearer = !!guest ? `Bearer ${apiKey}` : apiKey ? `Bearer ${decryptText(apiKey)}` : null
 
   const headers: any = {
     'Content-Type': 'application/json',
   }
 
-  if (!base.changed || mustUseThirdPartyPassword) {
+  if (bearer) {
     headers.Authorization = bearer
   }
 

--- a/srv/adapter/openai.ts
+++ b/srv/adapter/openai.ts
@@ -117,13 +117,15 @@ export const handleOAI: ModelAdapter = async function* (opts) {
 
   if (gen.antiBond) body.logit_bias = { 3938: -50, 11049: -50, 64186: -50, 3717: -25 }
 
-  const bearer = !!guest ? `Bearer ${user.oaiKey}` : `Bearer ${decryptText(user.oaiKey)}`
+  const mustUseThirdPartyPassword = base.changed && isThirdParty && user.thirdPartyPassword
+  const key = mustUseThirdPartyPassword ? user.thirdPartyPassword : user.oaiKey
+  const bearer = !!guest ? `Bearer ${key}` : `Bearer ${decryptText(key)}`
 
   const headers: any = {
     'Content-Type': 'application/json',
   }
 
-  if (!base.changed) {
+  if (!base.changed || mustUseThirdPartyPassword) {
     headers.Authorization = bearer
   }
 

--- a/srv/api/user/index.ts
+++ b/srv/api/user/index.ts
@@ -9,6 +9,7 @@ import {
   deleteOaiKey,
   deleteScaleKey,
   deleteClaudeKey,
+  deleteThirdPartyPassword,
   getConfig,
   getInitialLoad,
   getProfile,
@@ -31,6 +32,7 @@ router.delete('/config/horde', loggedIn, deleteHordeKey)
 router.delete('/config/novel', loggedIn, deleteNovelKey)
 router.delete('/config/openai', loggedIn, deleteOaiKey)
 router.delete('/config/claude', loggedIn, deleteClaudeKey)
+router.delete('/config/third-party', loggedIn, deleteThirdPartyPassword)
 router.delete('/presets/:id', loggedIn, deleteUserPreset)
 router.post('/password', loggedIn, changePassword)
 router.post('/config', loggedIn, updateConfig)

--- a/srv/api/user/settings.ts
+++ b/srv/api/user/settings.ts
@@ -299,6 +299,11 @@ async function getSafeUserConfig(userId: string) {
       user.claudeApiKey = ''
       user.claudeApiKeySet = true
     }
+
+    if (user.thirdPartyPassword) {
+      user.thirdPartyPassword = ''
+      user.thirdPartyPasswordSet = true
+    }
   }
   return user
 }

--- a/srv/api/user/settings.ts
+++ b/srv/api/user/settings.ts
@@ -51,6 +51,14 @@ export const deleteClaudeKey = handle(async ({ userId }) => {
   return { success: true }
 })
 
+export const deleteThirdPartyPassword = handle(async ({ userId }) => {
+  await store.users.updateUser(userId!, {
+    thirdPartyPassword: '',
+  })
+
+  return { success: true }
+})
+
 export const deleteHordeKey = handle(async ({ userId }) => {
   await store.users.updateUser(userId!, {
     hordeKey: '',
@@ -84,6 +92,7 @@ export const updateConfig = handle(async ({ userId, body }) => {
       novelModel: 'string?',
       koboldUrl: 'string?',
       thirdPartyFormat: 'string?',
+      thirdPartyPassword: 'string?',
       hordeUseTrusted: 'boolean?',
       oobaUrl: 'string?',
       hordeApiKey: 'string?',
@@ -185,6 +194,10 @@ export const updateConfig = handle(async ({ userId, body }) => {
 
   if (body.claudeApiKey) {
     update.claudeApiKey = encryptText(body.claudeApiKey)
+  }
+
+  if (body.thirdPartyPassword) {
+    update.thirdPartyPassword = encryptText(body.thirdPartyPassword)
   }
 
   await store.users.updateUser(userId!, update)

--- a/srv/db/schema.ts
+++ b/srv/db/schema.ts
@@ -36,6 +36,7 @@ export namespace AppSchema {
     koboldUrl: string
     thirdPartyFormat: 'kobold' | 'openai' | 'claude'
     thirdPartyPassword: string
+    thirdPartyPasswordSet?: boolean
     luminaiUrl: string
     oobaUrl: string
 

--- a/srv/db/schema.ts
+++ b/srv/db/schema.ts
@@ -35,6 +35,7 @@ export namespace AppSchema {
 
     koboldUrl: string
     thirdPartyFormat: 'kobold' | 'openai' | 'claude'
+    thirdPartyPassword: string
     luminaiUrl: string
     oobaUrl: string
 

--- a/srv/db/user.ts
+++ b/srv/db/user.ts
@@ -93,6 +93,7 @@ export async function createUser(newUser: NewUser, admin?: boolean) {
     defaultAdapter: 'horde',
     koboldUrl: '',
     thirdPartyFormat: 'kobold',
+    thirdPartyPassword: '',
     novelModel: NOVEL_MODELS.euterpe,
     luminaiUrl: '',
     oobaUrl: '',

--- a/web/pages/Settings/components/HordeAISettings.tsx
+++ b/web/pages/Settings/components/HordeAISettings.tsx
@@ -25,12 +25,7 @@ const HordeAISettings: Component<{
 
   const refreshHorde = () => {
     settingStore.getHordeModels()
-    try {
-      settingStore.getHordeWorkers()
-    } catch (e) {
-      console.log(e)
-      toastStore.warn('Error fetching horde workers. Check console for details.')
-    }
+    settingStore.getHordeWorkers()
   }
 
   const hordeName = createMemo(

--- a/web/pages/Settings/components/HordeAISettings.tsx
+++ b/web/pages/Settings/components/HordeAISettings.tsx
@@ -1,6 +1,6 @@
 import { Component, Show, createEffect, createMemo, createSignal } from 'solid-js'
 import TextInput from '../../../shared/TextInput'
-import { settingStore, userStore } from '../../../store'
+import { settingStore, toastStore, userStore } from '../../../store'
 import Button from '../../../shared/Button'
 import Select, { Option } from '../../../shared/Select'
 import { RefreshCw, Save, X } from 'lucide-solid'
@@ -25,7 +25,12 @@ const HordeAISettings: Component<{
 
   const refreshHorde = () => {
     settingStore.getHordeModels()
-    settingStore.getHordeWorkers()
+    try {
+      settingStore.getHordeWorkers()
+    } catch (e) {
+      console.log(e)
+      toastStore.warn('Error fetching horde workers. Check console for details.')
+    }
   }
 
   const hordeName = createMemo(

--- a/web/pages/Settings/components/KoboldAISettings.tsx
+++ b/web/pages/Settings/components/KoboldAISettings.tsx
@@ -2,6 +2,7 @@ import { Component } from 'solid-js'
 import Select from '../../../shared/Select'
 import TextInput from '../../../shared/TextInput'
 import { userStore } from '../../../store'
+import Button from '../../../shared/Button'
 
 const KoboldAISettings: Component = () => {
   const state = userStore()
@@ -15,7 +16,6 @@ const KoboldAISettings: Component = () => {
         placeholder="E.g. https://local-tunnel-url-10-20-30-40.loca.lt"
         value={state.user?.koboldUrl}
       />
-
       <Select
         fieldName="thirdPartyFormat"
         label="Kobold / 3rd-party Format"
@@ -27,6 +27,17 @@ const KoboldAISettings: Component = () => {
         ]}
         value={state.user?.thirdPartyFormat ?? 'kobold'}
       />
+      <TextInput
+        fieldName="thirdPartyPassword"
+        label="3rd-party password if applicable"
+        helperText="(NEVER put an OpenAI API key here, this would expose your personal information to third parties)"
+        placeholder={state.user?.thirdPartyPassword ? 'Password is set' : 'E.g. p4ssw0rd123'}
+        type="password"
+        value={''}
+      />
+      <Button schema="red" class="w-max" onClick={() => userStore.deleteKey('third-party')}>
+        Delete third-party password
+      </Button>
     </>
   )
 }

--- a/web/pages/Settings/components/KoboldAISettings.tsx
+++ b/web/pages/Settings/components/KoboldAISettings.tsx
@@ -31,7 +31,7 @@ const KoboldAISettings: Component = () => {
         fieldName="thirdPartyPassword"
         label="3rd-party password if applicable"
         helperText="(NEVER put an OpenAI API key here, this would expose your personal information to third parties)"
-        placeholder={state.user?.thirdPartyPassword ? 'Password is set' : 'E.g. p4ssw0rd123'}
+        placeholder={state.user?.thirdPartyPasswordSet ? 'Password is set' : 'E.g. p4ssw0rd123'}
         type="password"
         value={''}
       />

--- a/web/pages/Settings/index.tsx
+++ b/web/pages/Settings/index.tsx
@@ -41,6 +41,7 @@ const Settings: Component = () => {
       koboldUrl: 'string?',
       thirdPartyFormat: ['kobold', 'openai', 'claude'],
       oobaUrl: 'string?',
+      thirdPartyPassword: 'string?',
       novelApiKey: 'string?',
       novelModel: 'string?',
       hordeUseTrusted: 'boolean?',

--- a/web/store/data/storage.ts
+++ b/web/store/data/storage.ts
@@ -80,6 +80,7 @@ const fallbacks: { [key in StorageKey]: LocalStorage[key] } = {
     defaultAdapter: 'horde',
     koboldUrl: '',
     thirdPartyFormat: 'kobold',
+    thirdPartyPassword: '',
     luminaiUrl: '',
   },
   profile: { _id: '', kind: 'profile', userId: ID, handle: 'You' },

--- a/web/store/data/user.ts
+++ b/web/store/data/user.ts
@@ -71,6 +71,10 @@ export async function deleteApiKey(kind: string) {
     user.claudeApiKey = ''
   }
 
+  if (kind === 'third-party') {
+    user.thirdPartyPassword = ''
+  }
+
   local.saveConfig(user)
   return local.result({ success: true })
 }

--- a/web/store/user.ts
+++ b/web/store/user.ts
@@ -197,7 +197,10 @@ export const userStore = createStore<UserState>(
       return { background: file.content }
     },
 
-    async deleteKey({ user }, kind: 'novel' | 'horde' | 'openai' | 'scale' | 'claude') {
+    async deleteKey(
+      { user },
+      kind: 'novel' | 'horde' | 'openai' | 'scale' | 'claude' | 'third-party'
+    ) {
       const res = await data.user.deleteApiKey(kind)
       if (res.error) return toastStore.error(`Failed to update settings: ${res.error}`)
 
@@ -212,6 +215,9 @@ export const userStore = createStore<UserState>(
 
       if (kind === 'claude') {
         return { user: { ...user, claudeApiKey: '', claudeApiKeySet: false } }
+      }
+      if (kind === 'third-party') {
+        return { user: { ...user, thirdPartyPassword: '' } }
       }
     },
 


### PR DESCRIPTION
- add a setting to use a password/key on third-party backends whose interfaces mimic openai/claude
- (also: added a dumb try-catch to not throw if fetching horde data fails)

this PR can serve as a clean example of what files need to be changed to add a new setting.