### PR TITLE
feat: add openai snapshot models (closes #247)

### DIFF
--- a/common/adapters.ts
+++ b/common/adapters.ts
@@ -54,7 +54,9 @@ export type OpenAIModel = (typeof OPENAI_MODELS)[keyof typeof OPENAI_MODELS]
 export const OPENAI_MODELS = {
   DaVinci: 'text-davinci-003',
   Turbo: 'gpt-3.5-turbo',
+  Turbo0301: 'gpt-3.5-turbo-0301',
   GPT4: 'gpt-4',
+  GPT40314: 'gpt-4-0314',
 } as const
 
 /** Note: claude-v1 and claude-instant-v1 not included as they may point


### PR DESCRIPTION
(closes #247)

The regular turbo and gpt-4 builds seem to get periodically updated with anti-RP RLHF. Snapshots are temporary, but worth having while still available.