### PR TITLE
fix: properly save memory book entries enabled/disabled status

### DIFF
--- a/web/pages/Memory/EditMemory.tsx
+++ b/web/pages/Memory/EditMemory.tsx
@@ -33,7 +33,7 @@ const emptyEntry: AppSchema.MemoryEntry = {
   keywords: [],
   priority: 0,
   weight: 0,
-  enabled: true,
+  enabled: false,
 }
 
 const missingFieldsInEntry = (entry: AppSchema.MemoryEntry): (keyof AppSchema.MemoryEntry)[] => [
@@ -352,10 +352,6 @@ export function getBookUpdate(ref: Event | HTMLFormElement) {
     if (i === undefined) continue
 
     const prev = map.get(i) || { ...emptyEntry }
-    // If an entry is enabled, its value will be `"on"`. If it's disabled, its
-    // value will be omitted from the `inputs` array, so we set it to `false` by
-    // default and it will be changed to `true` if it is enabled.
-    prev.enabled = false
 
     switch (prop) {
       case 'name':


### PR DESCRIPTION
closes #265
high priority fix, sorry for introducing the bug.

bug was that prev.enabled's `false` default was set for every prop, so it would be reset to false unless `enabled` was the last processed prop.

this is changed so that prev.enabled is set to `false` not for every prop, but before processing any prop.