### PR TITLE
fix: make turbo and gpt4 snapshot models use the chat endpoint

### DIFF
--- a/common/adapters.ts
+++ b/common/adapters.ts
@@ -56,7 +56,7 @@ export const OPENAI_MODELS = {
   Turbo: 'gpt-3.5-turbo',
   Turbo0301: 'gpt-3.5-turbo-0301',
   GPT4: 'gpt-4',
-  GPT40314: 'gpt-4-0314',
+  GPT4_0314: 'gpt-4-0314',
 } as const
 
 /** Note: claude-v1 and claude-instant-v1 not included as they may point

--- a/srv/adapter/openai.ts
+++ b/srv/adapter/openai.ts
@@ -18,7 +18,9 @@ type OpenAIMessagePropType = {
 
 const CHAT_MODELS: Record<string, boolean> = {
   [OPENAI_MODELS.Turbo]: true,
+  [OPENAI_MODELS.Turbo0301]: true,
   [OPENAI_MODELS.GPT4]: true,
+  [OPENAI_MODELS.GPT4_0314]: true,
 }
 
 export const handleOAI: ModelAdapter = async function* (opts) {


### PR DESCRIPTION
Another episode of me being a dumbass. Tested to work this time.