### PR TITLE
Fix char description dropped when creating

### DIFF
--- a/web/store/data/chars.ts
+++ b/web/store/data/chars.ts
@@ -135,6 +135,7 @@ export async function createCharacter(char: ImportCharacter) {
   if (isLoggedIn()) {
     const form = new FormData()
     form.append('name', char.name)
+    if (char.description) form.append('description', char.description)
     form.append('greeting', char.greeting)
     form.append('scenario', char.scenario)
     form.append('persona', JSON.stringify(char.persona))


### PR DESCRIPTION
Like the title says, creating a new character right now ignores the description field. This fixes that.