### PR TITLE
fix: use different icon for card menu in charlist, mobile list-view

### DIFF
--- a/web/pages/Character/CharacterList.tsx
+++ b/web/pages/Character/CharacterList.tsx
@@ -19,6 +19,7 @@ import {
   Download,
   Edit,
   Menu,
+  MoreHorizontal,
   Save,
   Trash,
   VenetianMask,
@@ -356,7 +357,7 @@ const Character: Component<{
             <Trash class="icon-button" onClick={props.delete} />
           </div>
           <div class="flex items-center sm:hidden" onClick={() => setListOpts(true)}>
-            <Menu class="icon-button" />
+            <MoreHorizontal class="icon-button" />
           </div>
           <DropMenu
             class="bg-[var(--bg-700)]"


### PR DESCRIPTION
old one (burger) looked too much like an invitation to drag and drop lines to rearrange them

## Before

![1683291936](https://user-images.githubusercontent.com/128472336/236465971-3dc280b4-84f7-434c-81e8-81298a01cd69.png)

## After

![1683291948](https://user-images.githubusercontent.com/128472336/236466025-36aed6d4-dbc1-42f3-af85-0a5595c85c83.png)
