### PR TITLE
fix: add padding to make preset save button accessible on mobile

### DIFF
--- a/web/pages/GenerationPresets/index.tsx
+++ b/web/pages/GenerationPresets/index.tsx
@@ -120,7 +120,7 @@ export const GenerationPresetsPage: Component = () => {
   return (
     <>
       <PageHeader title="Generation Presets" subtitle="Generation presets" />
-      <div class="flex flex-col gap-2">
+      <div class="flex flex-col gap-2 pb-10">
         <Show when={params.id === 'default'}>
           <div class="font-bold">
             This is a default preset and cannot be saved.{' '}


### PR DESCRIPTION
Has been reported that the preset save button is not accessible on certain mobile browsers (presumably hidden by URL bar).

This PR adds padding so the save button doesn't hug the bottom of the viewport.

### before

![1683293210](https://user-images.githubusercontent.com/128472336/236470505-ca1a4ab7-33be-46cd-a1eb-4cdd29ca43a9.png)

### after

![1683293196](https://user-images.githubusercontent.com/128472336/236470561-e59f1735-6403-4c74-b4f0-e30cc61091fc.png)