### PR TITLE
Support versioned third-party API URLs in OpenAI adapter

### DIFF
--- a/srv/adapter/openai.ts
+++ b/srv/adapter/openai.ts
@@ -137,7 +137,7 @@ export const handleOAI: ModelAdapter = async function* (opts) {
 
   log.debug(body, 'OpenAI payload')
 
-  const url = useChat ? `${base.url}/v1/chat/completions` : `${base.url}/v1/completions`
+  const url = useChat ? `${base.url}/chat/completions` : `${base.url}/completions`
 
   const resp = await needle('post', url, JSON.stringify(body), {
     json: true,
@@ -187,9 +187,7 @@ function getBaseUrl(user: AppSchema.User, isThirdParty?: boolean) {
   if (isThirdParty && user.thirdPartyFormat === 'openai' && user.koboldUrl) {
     // If the user provides a versioned API URL for their third-party API, use that. Otherwise
     // fall back to the standard /v1 URL.
-
     const version = user.koboldUrl.match(/\/v\d+$/) ? '' : '/v1'
-
     return { url: user.koboldUrl + version, changed: true }
   }
 

--- a/srv/adapter/openai.ts
+++ b/srv/adapter/openai.ts
@@ -185,10 +185,15 @@ export const handleOAI: ModelAdapter = async function* (opts) {
 
 function getBaseUrl(user: AppSchema.User, isThirdParty?: boolean) {
   if (isThirdParty && user.thirdPartyFormat === 'openai' && user.koboldUrl) {
-    return { url: user.koboldUrl, changed: true }
+    // If the user provides a versioned API URL for their third-party API, use that. Otherwise
+    // fall back to the standard /v1 URL.
+
+    const version = user.koboldUrl.match(/\/v\d+$/) ? '' : '/v1'
+
+    return { url: user.koboldUrl + version, changed: true }
   }
 
-  return { url: baseUrl, changed: false }
+  return { url: `${baseUrl}/v1`, changed: false }
 }
 
 export type OAIUsage = {


### PR DESCRIPTION
Currently Agnaistic adds `/v1` to whatever URL a user inputs as their preferred third party OpenAI-compatible API URL.  This can break certain third-party OpenAI-compatible APIs which expect requests to come into `example.com/v2/chat/completions`.

This PR adjusts `getBaseUrl` in the OpenAI adapter to not append `/v1` if the user inputs a URL which already ends in another version. Otherwise it works exactly the same as it did previously.

Input > URL
`example.com/api` > `example.com/api/v1/chat/completions`
`example.com/api/v1` > `example.com/api/v1/chat/completions`
`example.com/api/v2` > `example.com/api/v2/chat/completions`