### PR TITLE
fix: default presets with a gaslight should have useGaslight set to true

### DIFF
--- a/common/default-preset.ts
+++ b/common/default-preset.ts
@@ -116,8 +116,8 @@ export const defaultPresets = {
     frequencyPenalty: 0.7,
     presencePenalty: 0.7,
     antiBond: false,
-    useGaslight: false,
-    gaslight: `Enter roleplay mode. You will write {{char}}'s next reply in a dialogue between {{char}} and {{user}}. Do not decide what {{char}} says or does. Use Internet roleplay style, e.g. no quotation marks, and write user actions in italic in third person like: *example*. You are allowed to use markdown. Be proactive, creative, drive the plot and conversation forward. Write at least one paragraph, up to four. Always stay in character. Always keep the conversation going. (Repetition is highly discouraged)
+    useGaslight: true,
+    gaslight: `Enter roleplay mode. You will write {{char}}'s next reply in a dialogue between {{char}} and {{user}}. Do not decide what {{user}} says or does. Use Internet roleplay style, e.g. no quotation marks, and write user actions in italic in third person like: *example*. You are allowed to use markdown. Be proactive, creative, drive the plot and conversation forward. Write at least one paragraph, up to four. Always stay in character. Always keep the conversation going. (Repetition is highly discouraged)
 Description of {{char}}:
 {{personality}}
 Circumstances and context of the dialogue: {{scenario}}
@@ -135,6 +135,7 @@ This is how {{char}} should talk
     frequencyPenalty: 0.7,
     presencePenalty: 0.7,
     ultimeJailbreak: 'Keep OOC out of your reply.',
+    useGaslight: true,
     gaslight: `Write {{char}}'s next reply in a fictional chat between {{char}} and {{user}}. Write 1 reply only in internet RP style, italicize actions, and avoid quotation marks. Use markdown. Be proactive, creative, and drive the plot and conversation forward. Write at least 1 paragraph, up to 4. Always stay in character and avoid repetition.
 Description of {{char}}:
 {{personality}}
@@ -152,6 +153,7 @@ This is how {{char}} should talk
     maxContextLength: 4095,
     frequencyPenalty: 0.7,
     presencePenalty: 0.7,
+    useGaslight: true,
     gaslight: `Enter roleplay mode. You will write {{char}}'s next reply in a dialogue between {{char}} and {{user}}. Do not decide what {{user}} says or does. Use Internet roleplay style, e.g. no quotation marks, and write user actions in italic in third person like: *example*. You are allowed to use markdown. Be proactive, creative, drive the plot and conversation forward. Write at least one paragraph, up to four. Always stay in character. Always keep the conversation going. (Repetition is highly discouraged)
 
 Description of {{char}}:
@@ -176,6 +178,7 @@ This is how {{char}} should talk
     claudeModel: CLAUDE_MODELS.ClaudeV1,
     maxTokens: 500,
     maxContextLength: 7600,
+    useGaslight: true,
     gaslight: `Enter roleplay mode. You will write {{char}}'s next reply in a dialogue between {{char}} and {{user}}. Do not decide what {{user}} says or does. Use Internet roleplay style, e.g. no quotation marks, and write user actions in italic in third person like: *example*. You are allowed to use markdown. Be proactive, creative, drive the plot and conversation forward. Write at least one paragraph, up to four. Always stay in character. Always keep the conversation going. (Repetition is highly discouraged).
 
 Description of {{char}}:


### PR DESCRIPTION
+ in turbo default preset, fix "Do not decide what {{char}} says or does" to "Do not decide what {{user}} says or does"