### PR TITLE
fix: load every msg from the start for claude 100k

### DIFF
--- a/srv/api/chat/get.ts
+++ b/srv/api/chat/get.ts
@@ -11,8 +11,9 @@ export const getCharacterChats = handle(async (req) => {
   return { character, chats: list }
 })
 
-export const getChatDetail = handle(async ({ userId, params }) => {
+export const getChatDetail = handle(async ({ userId, params, query }) => {
   const id = params.id
+  const isAbsurdContextSize = query.isAbsurdContextSize === 'true'
   const detail = await store.chats.getChat(id)
 
   if (!detail) throw errors.NotFound
@@ -29,7 +30,7 @@ export const getChatDetail = handle(async ({ userId, params }) => {
 
   const character = detail.characters.find((ch) => ch._id === detail.chat.characterId)
 
-  const messages = await store.msgs.getMessages(id)
+  const messages = await store.msgs.getMessages({ chatId: id, everySingleMessage: isAbsurdContextSize })
 
   return { messages, character, members, active, ...detail }
 })

--- a/srv/api/chat/message.ts
+++ b/srv/api/chat/message.ts
@@ -47,7 +47,7 @@ export const getMessages = handle(async ({ userId, params, query }) => {
   assertValid({ before: 'string' }, query)
   const before = query.before
 
-  const messages = await store.msgs.getMessages(chatId, before)
+  const messages = await store.msgs.getMessages({ chatId, before, everySingleMessage: false })
   return { messages }
 })
 

--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -145,8 +145,11 @@ const ChatDetail: Component = () => {
       if (!chats.lastId) return nav('/character/list')
       return nav(`/chat/${chats.lastId}`)
     }
-
-    chatStore.getChat(params.id)
+    const isAbsurdContextSize = createMemo(() => {
+      const ctxLimit = chatPreset()?.contextLimit
+      return !!ctxLimit && ctxLimit > 10000
+    })
+    chatStore.getChat(params.id, isAbsurdContextSize())
   })
 
   const sendMessage = (message: string, ooc: boolean, onSuccess?: () => void) => {

--- a/web/store/chat.ts
+++ b/web/store/chat.ts
@@ -140,14 +140,14 @@ export const chatStore = createStore<ChatState>('chat', {
         }
       }
     },
-    async *getChat(_, id: string) {
+    async *getChat(_, id: string, isAbsurdContextSize: boolean) {
       yield { loaded: false }
       msgStore.setState({
         msgs: [],
         activeChatId: id,
         activeCharId: undefined,
       })
-      const res = await chatsApi.getChat(id)
+      const res = await chatsApi.getChat(id, isAbsurdContextSize)
       yield { loaded: true }
 
       if (res.error) toastStore.error(`Failed to retrieve conversation: ${res.error}`)

--- a/web/store/data/chats.ts
+++ b/web/store/data/chats.ts
@@ -21,7 +21,7 @@ export const chatsApi = {
   removeCharacter,
 }
 
-export async function getChat(id: string) {
+export async function getChat(id: string, isAbsurdContextSize: boolean) {
   if (isLoggedIn()) {
     const res = await api.get<{
       chat: AppSchema.Chat
@@ -30,7 +30,7 @@ export async function getChat(id: string) {
       characters: AppSchema.Character[]
       members: AppSchema.Profile[]
       active: string[]
-    }>(`/chat/${id}`)
+    }>(`/chat/${id}`, { isAbsurdContextSize: String(isAbsurdContextSize) })
     return res
   }
 


### PR DESCRIPTION
tentatively closes #347 
workaround for claude 100k not including unloaded messages. the workaround is to load every single message if the preset context size is over 10000 tokens.
this might not be a satisfactory solution, must review.