### PR TITLE
Fix NovelAI preset copies not using clio, add NovelAI model to presets

### DIFF
--- a/common/adapters.ts
+++ b/common/adapters.ts
@@ -179,7 +179,7 @@ export const adapterSettings: {
   typicalP: ['horde', 'novel', 'kobold', 'ooba', 'luminai'],
 
   claudeModel: ['claude', 'kobold'],
-
+  novelModel: ['novel'],
   oaiModel: ['openai', 'kobold'],
   frequencyPenalty: ['openai', 'kobold', 'novel'],
   presencePenalty: ['openai', 'kobold', 'novel'],

--- a/common/default-preset.ts
+++ b/common/default-preset.ts
@@ -1,5 +1,5 @@
 import { AppSchema } from '../srv/db/schema'
-import { CLAUDE_MODELS, OPENAI_MODELS } from './adapters'
+import { CLAUDE_MODELS, NOVEL_MODELS, OPENAI_MODELS } from './adapters'
 
 const MAX_TOKENS = 80
 
@@ -65,6 +65,7 @@ const builtinPresets = {
   novel_clio: {
     name: 'Novel Clio - Talker C',
     service: 'novel',
+    novelModel: NOVEL_MODELS.clio_v1,
     maxTokens: 300,
     maxContextLength: 8000,
     repetitionPenalty: 1.5,

--- a/common/presets.ts
+++ b/common/presets.ts
@@ -32,7 +32,7 @@ export const chatGenSettings = {
   presencePenalty: 'number',
   gaslight: 'string',
   oaiModel: 'string',
-  novelModel: 'string',
+  novelModel: 'string?',
   claudeModel: 'string',
   streamResponse: 'boolean?',
   useGaslight: 'boolean?',

--- a/common/presets.ts
+++ b/common/presets.ts
@@ -32,6 +32,7 @@ export const chatGenSettings = {
   presencePenalty: 'number',
   gaslight: 'string',
   oaiModel: 'string',
+  novelModel: 'string',
   claudeModel: 'string',
   streamResponse: 'boolean?',
   useGaslight: 'boolean?',
@@ -135,6 +136,7 @@ export const serviceGenMap: Record<Exclude<ChatAdapter, 'default'>, GenMap> = {
     typicalP: 'typical_p',
     topA: 'top_a',
     order: '',
+    novelModel: 'novelModel',
   },
   ooba: {
     maxTokens: 'max_new_tokens',

--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -1,6 +1,6 @@
 import type { GenerateRequestV2 } from '../srv/adapter/type'
 import type { AppSchema } from '../srv/db/schema'
-import { AIAdapter, OPENAI_MODELS } from './adapters'
+import { AIAdapter, NOVEL_MODELS, OPENAI_MODELS } from './adapters'
 import { IMAGE_SUMMARY_PROMPT } from './image'
 import { buildMemoryPrompt, MEMORY_PREFIX } from './memory'
 import { defaultPresets, getFallbackPreset, isDefaultPreset } from './presets'
@@ -555,7 +555,11 @@ function getContextLimit(
     case 'ooba':
       return configuredMax - genAmount
 
-    case 'novel':
+    case 'novel': {
+      if (model === NOVEL_MODELS.clio_v1) return 8000 - genAmount
+      return configuredMax - genAmount
+    }
+
     case 'horde':
 
     case 'openai': {

--- a/srv/adapter/novel.ts
+++ b/srv/adapter/novel.ts
@@ -5,7 +5,6 @@ import { badWordIds, clioBadWordsId } from './novel-bad-words'
 import { ModelAdapter } from './type'
 import { AppSchema } from '../db/schema'
 import { NOVEL_MODELS } from '/common/adapters'
-import { defaultPresets } from '/common/default-preset'
 import { needleToSSE } from './stream'
 import { AppLog } from '../logger'
 
@@ -28,8 +27,6 @@ const statuses: Record<number, string> = {
   401: 'Invalid API key',
   402: 'You need an active subscription',
 }
-
-const newModelPresets = new Set([defaultPresets.novel_clio.name])
 
 const base = {
   generate_until_sentence: true,
@@ -58,7 +55,7 @@ export const handleNovel: ModelAdapter = async function* ({
     return
   }
 
-  const model = newModelPresets.has(opts.gen.name || '') ? NOVEL_MODELS.clio_v1 : user.novelModel
+  const model = opts.gen.novelModel || user.novelModel || NOVEL_MODELS.euterpe
 
   const body = {
     model,
@@ -69,6 +66,8 @@ export const handleNovel: ModelAdapter = async function* ({
   const endTokens = ['***', 'Scenario:', '----']
 
   log.debug({ ...body, parameters: { ...body.parameters, bad_word_ids: null } }, 'NovelAI payload')
+
+  console.log('NovelAI payload', JSON.stringify(body, null, 2))
 
   const headers = {
     Authorization: `Bearer ${guest ? user.novelApiKey : decryptText(user.novelApiKey)}`,

--- a/srv/db/schema.ts
+++ b/srv/db/schema.ts
@@ -224,6 +224,7 @@ export namespace AppSchema {
     frequencyPenalty?: number
     presencePenalty?: number
     oaiModel?: string
+    novelModel?: string
     claudeModel?: string
     streamResponse?: boolean
 

--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -426,7 +426,7 @@ const CharacterResponseBtn: Component<{
   return (
     <Show when={props.char}>
       <div
-        class={`flex max-w-[200px] overflow-hidden px-2 py-1 ${cursor()} items-center rounded-md border-[1px] border-[var(--bg-800)] hover:bg-[var(--bg-800)]`}
+        class={`flex max-w-[200px] overflow-hidden px-2 py-1 ${cursor()} items-center rounded-md border-[1px] border-[var(--bg-800)] bg-[var(--bg-900)] hover:bg-[var(--bg-800)]`}
         onclick={() => !props.waiting && props.request(props.char._id)}
       >
         <AvatarIcon

--- a/web/pages/Chat/ChatGenSettings.tsx
+++ b/web/pages/Chat/ChatGenSettings.tsx
@@ -129,7 +129,7 @@ export const ChatGenSettingsModal: Component<{
       show={props.show}
       close={props.close}
       footer={Footer}
-      title="Chat Generation Settings"
+      title="Generation Settings"
       fixedHeight
       maxWidth="half"
     >

--- a/web/pages/Settings/components/NovelAISettings.tsx
+++ b/web/pages/Settings/components/NovelAISettings.tsx
@@ -16,7 +16,7 @@ const NovelAISettings: Component = () => {
     <>
       <Select
         fieldName="novelModel"
-        label="NovelAI Model"
+        label="Default NovelAI Model"
         items={[
           { label: 'Euterpe', value: 'euterpe-v2' },
           { label: 'Krake', value: 'krake-v2' },

--- a/web/shared/GenerationSettings.tsx
+++ b/web/shared/GenerationSettings.tsx
@@ -117,7 +117,7 @@ const GeneralSettings: Component<Props> = (props) => {
         fieldName="novelModel"
         label="NovelAI Model"
         items={[...modelsToItems(NOVEL_MODELS), { value: '', label: 'Use service default' }]}
-        helperText="Which NovelaI model to use"
+        helperText="Which NovelAI model to use"
         value={props.inherit?.novelModel || ''}
         disabled={props.disabled}
         service={props.service}

--- a/web/shared/GenerationSettings.tsx
+++ b/web/shared/GenerationSettings.tsx
@@ -4,7 +4,13 @@ import TextInput from './TextInput'
 import Select, { Option } from './Select'
 import { AppSchema } from '../../srv/db/schema'
 import { defaultPresets } from '../../common/presets'
-import { OPENAI_MODELS, CLAUDE_MODELS, ADAPTER_LABELS, AIAdapter } from '../../common/adapters'
+import {
+  OPENAI_MODELS,
+  CLAUDE_MODELS,
+  ADAPTER_LABELS,
+  AIAdapter,
+  NOVEL_MODELS,
+} from '../../common/adapters'
 import Divider from './Divider'
 import { Toggle } from './Toggle'
 import { Check, X } from 'lucide-solid'
@@ -105,6 +111,17 @@ const GeneralSettings: Component<Props> = (props) => {
         disabled={props.disabled}
         service={props.service}
         aiSetting={'oaiModel'}
+      />
+
+      <Select
+        fieldName="novelModel"
+        label="NovelAI Model"
+        items={[...modelsToItems(NOVEL_MODELS), { value: '', label: 'Use service default' }]}
+        helperText="Which NovelaI model to use"
+        value={props.inherit?.novelModel || ''}
+        disabled={props.disabled}
+        service={props.service}
+        aiSetting={'novelModel'}
       />
 
       <Select


### PR DESCRIPTION
To avoid breaking changes, I left the NovelAI model in AI settings, but named it "default" model. NovelAI can now be configured per preset, like claude and oai.

This also fixes the issue that making a copy of the clio preset would become non-clio.