### PR TITLE
Fix: Avoid complete startup crash without local storage

### DIFF
--- a/web/pages/Character/CharacterList.tsx
+++ b/web/pages/Character/CharacterList.tsx
@@ -38,7 +38,7 @@ import { A, useNavigate, useSearchParams } from '@solidjs/router'
 import AvatarIcon from '../../shared/AvatarIcon'
 import ImportCharacterModal from '../Character/ImportCharacter'
 import DeleteCharacterModal from '../Character/DeleteCharacter'
-import { getAssetUrl, setComponentPageTitle } from '../../shared/util'
+import { getAssetUrl, safeLocalStorage, setComponentPageTitle } from '../../shared/util'
 import { DropMenu } from '../../shared/DropMenu'
 import Button from '../../shared/Button'
 import Modal from '../../shared/Modal'
@@ -559,7 +559,7 @@ function getSortFunction(field: SortFieldTypes, direction: SortDirectionTypes) {
 }
 
 function getListCache(): ListCache {
-  const existing = localStorage.getItem(CACHE_KEY)
+  const existing = safeLocalStorage.getItem(CACHE_KEY)
   const defaultCache: ListCache = { sort: { field: 'modified', direction: 'desc' }, view: 'list' }
 
   if (!existing) {
@@ -570,7 +570,7 @@ function getListCache(): ListCache {
 }
 
 function saveListCache(cache: ListCache) {
-  localStorage.setItem(CACHE_KEY, JSON.stringify(cache))
+  safeLocalStorage.setItem(CACHE_KEY, JSON.stringify(cache))
 }
 
 const plainFormats = [{ value: 'text', label: 'Plain Text' }]

--- a/web/pages/Character/util.ts
+++ b/web/pages/Character/util.ts
@@ -1,4 +1,5 @@
 import { AppSchema } from '/srv/db/schema'
+import { safeLocalStorage } from '/web/shared/util'
 
 const CACHE_KEY = 'agnai-chatlist-cache'
 
@@ -108,7 +109,7 @@ export function groupAndSort(
 }
 
 export function getListCache(): ListCache {
-  const existing = localStorage.getItem(CACHE_KEY)
+  const existing = safeLocalStorage.getItem(CACHE_KEY)
   const defaultCache: ListCache = { sort: { field: 'chat-updated', direction: 'desc' } }
 
   if (!existing) {
@@ -119,5 +120,5 @@ export function getListCache(): ListCache {
 }
 
 export function saveListCache(cache: ListCache) {
-  localStorage.setItem(CACHE_KEY, JSON.stringify(cache))
+  safeLocalStorage.setItem(CACHE_KEY, JSON.stringify(cache))
 }

--- a/web/shared/util.ts
+++ b/web/shared/util.ts
@@ -15,9 +15,71 @@ type FormRef = {
     | 'boolean?'
 }
 
+export const safeLocalStorage = {
+  getItem(key: string) {
+    try {
+      return localStorage.getItem(key)
+    } catch {
+      return null
+    }
+  },
+
+  key(index: number) {
+    try {
+      return localStorage.key(index)
+    } catch {
+      return null
+    }
+  },
+
+  setItem(key: string, value: string) {
+    try {
+      localStorage.setItem(key, value)
+    } catch (e: any) {
+      console.warn('Failed to set local storage item', key, value, e)
+    }
+  },
+
+  setItemUnsafe(key: string, value: string) {
+    localStorage.setItem(key, value)
+  },
+
+  removeItem(key: string) {
+    try {
+      localStorage.removeItem(key)
+    } catch (e: any) {
+      console.warn('Failed to remove local storage item', key, e)
+    }
+  },
+
+  removeItemUnsafe(key: string) {
+    localStorage.removeItem(key)
+  },
+
+  clear() {
+    try {
+      localStorage.clear()
+    } catch (e: any) {
+      console.warn('Failed to clear local storage item', e)
+    }
+  },
+
+  clearUnsafe() {
+    localStorage.clear()
+  },
+
+  test() {
+    const TEST_KEY = '___TEST'
+    localStorage.setItem(TEST_KEY, 'ok')
+    const value = localStorage.getItem(TEST_KEY)
+    localStorage.removeItem(TEST_KEY)
+    if (value !== 'ok') throw new Error('Failed to retreive set local storage item')
+  },
+}
+
 const PREFIX_CACHE_KEY = 'agnai-asset-prefix'
 
-let assetPrefix: string = localStorage.getItem(PREFIX_CACHE_KEY) || ''
+let assetPrefix: string = safeLocalStorage.getItem(PREFIX_CACHE_KEY) || ''
 
 export function getAssetPrefix() {
   return assetPrefix
@@ -43,7 +105,7 @@ export function getAssetUrl(filename: string) {
 }
 
 export function setAssetPrefix(prefix: string) {
-  localStorage.setItem(PREFIX_CACHE_KEY, prefix)
+  safeLocalStorage.setItem(PREFIX_CACHE_KEY, prefix)
   assetPrefix = prefix
 }
 

--- a/web/store/chat.ts
+++ b/web/store/chat.ts
@@ -3,6 +3,7 @@ import { getEncoder } from '../../common/tokenize'
 import { AppSchema } from '../../srv/db/schema'
 import { EVENTS, events } from '../emitter'
 import type { ChatModal } from '../pages/Chat/ChatOptions'
+import { safeLocalStorage } from '../shared/util'
 import { api } from './api'
 import { characterStore } from './character'
 import { createStore, getStore } from './create'
@@ -94,7 +95,7 @@ const EDITING_KEY = 'chat-detail-settings'
 
 export const chatStore = createStore<ChatState>('chat', {
   lastFetched: 0,
-  lastChatId: localStorage.getItem('lastChatId'),
+  lastChatId: safeLocalStorage.getItem('lastChatId'),
   loaded: false,
   chatProfiles: [],
   chatBots: [],
@@ -156,7 +157,7 @@ export const chatStore = createStore<ChatState>('chat', {
 
       if (res.error) toastStore.error(`Failed to retrieve conversation: ${res.error}`)
       if (res.result) {
-        localStorage.setItem('lastChatId', id)
+        safeLocalStorage.setItem('lastChatId', id)
 
         msgStore.setState({
           msgs: res.result.messages,
@@ -531,12 +532,12 @@ type ChatOptCache = { editing: boolean; hideOoc: boolean }
 
 function saveOptsCache(cache: ChatOptCache) {
   const prev = getOptsCache()
-  localStorage.setItem(EDITING_KEY, JSON.stringify({ ...prev, ...cache }))
+  safeLocalStorage.setItem(EDITING_KEY, JSON.stringify({ ...prev, ...cache }))
 }
 
 function getOptsCache(): ChatOptCache {
   const prev =
-    localStorage.getItem(EDITING_KEY) || JSON.stringify({ editing: false, hideOoc: false })
+    safeLocalStorage.getItem(EDITING_KEY) || JSON.stringify({ editing: false, hideOoc: false })
   const body = JSON.parse(prev)
   return { editing: false, hideOoc: false, ...body, modal: undefined }
 }

--- a/web/store/data/storage.ts
+++ b/web/store/data/storage.ts
@@ -4,6 +4,7 @@ import { defaultChars } from '../../../common/characters'
 import { AppSchema } from '../../../srv/db/schema'
 import { api } from '../api'
 import { toastStore } from '../toasts'
+import { safeLocalStorage } from '/web/shared/util'
 
 type StorageKey = keyof typeof KEYS
 
@@ -161,7 +162,7 @@ export function saveMessages(chatId: string, messages: AppSchema.ChatMessage[]) 
     api.post(`/json/messages/${chatId}`, messages)
   } else {
     const key = `messages-${chatId}`
-    localStorage.setItem(key, JSON.stringify(messages))
+    safeLocalStorage.setItem(key, JSON.stringify(messages))
   }
 }
 
@@ -178,7 +179,7 @@ export async function getMessages(
     }
   }
 
-  const messages = localStorage.getItem(`messages-${chatId}`)
+  const messages = safeLocalStorage.getItem(`messages-${chatId}`)
   if (!messages) return []
 
   return JSON.parse(messages) as AppSchema.ChatMessage[]
@@ -209,7 +210,7 @@ export function saveBooks(state: AppSchema.MemoryBook[]) {
 }
 
 export function deleteChatMessages(chatId: string) {
-  localStorage.removeItem(`messages-${chatId}`)
+  safeLocalStorage.removeItem(`messages-${chatId}`)
 }
 
 function saveItem<TKey extends keyof typeof KEYS>(key: TKey, value: LocalStorage[TKey]) {
@@ -218,7 +219,7 @@ function saveItem<TKey extends keyof typeof KEYS>(key: TKey, value: LocalStorage
     api.post('/json', { [key]: value })
   } else {
     localStore.set(key, value)
-    localStorage.setItem(KEYS[key], JSON.stringify(value))
+    safeLocalStorage.setItem(KEYS[key], JSON.stringify(value))
   }
 }
 
@@ -227,7 +228,7 @@ export function loadItem<TKey extends keyof typeof KEYS>(
   local?: boolean
 ): LocalStorage[TKey] {
   if (local || !selfHosting()) {
-    const item = localStorage.getItem(KEYS[key])
+    const item = safeLocalStorage.getItem(KEYS[key])
     if (item) {
       const parsed = JSON.parse(item)
       localStore.set(key, parsed)
@@ -235,7 +236,7 @@ export function loadItem<TKey extends keyof typeof KEYS>(
     }
 
     const fallback = fallbacks[key]
-    localStorage.setItem(key, JSON.stringify(fallback))
+    safeLocalStorage.setItem(key, JSON.stringify(fallback))
 
     return fallback
   }

--- a/web/store/tag.ts
+++ b/web/store/tag.ts
@@ -1,3 +1,4 @@
+import { safeLocalStorage } from '../shared/util'
 import { createStore } from './create'
 import { AppSchema } from '/srv/db/schema'
 
@@ -57,7 +58,7 @@ export const tagStore = createStore<TagsState>(
       if (!restoredFromCache) {
         restoredFromCache = true
         try {
-          const cache = localStorage.getItem(TAG_CACHE_KEY)
+          const cache = safeLocalStorage.getItem(TAG_CACHE_KEY)
           if (cache) {
             const { filter: f, hidden: h } = JSON.parse(cache)
             filter = f
@@ -73,7 +74,7 @@ export const tagStore = createStore<TagsState>(
     setDefault() {
       const next = { filter: [], hidden: defaultHidden }
       try {
-        localStorage.setItem(TAG_CACHE_KEY, JSON.stringify(next))
+        safeLocalStorage.setItem(TAG_CACHE_KEY, JSON.stringify(next))
       } catch (e) {
         console.warn('Failed to save tags in local storage', e)
       }
@@ -89,7 +90,7 @@ export const tagStore = createStore<TagsState>(
         next = { filter: prev.filter.concat(tag), hidden: prev.hidden }
       }
       try {
-        localStorage.setItem(TAG_CACHE_KEY, JSON.stringify(next))
+        safeLocalStorage.setItem(TAG_CACHE_KEY, JSON.stringify(next))
       } catch (e) {
         console.warn('Failed to save tags in local storage', e)
       }


### PR DESCRIPTION
I recently had trouble on mobile, the site would load completely black. I could not reproduce normally on desktop to diagnose, but I know adding localStorage.clear() fixed all my problems.

This PR at least allows the site to load, so I could at least go and delete some character images and restore the site. It will also allow the site to load on desktops where local storage has been completely disabled (obviously with some problems)