### PR TITLE
feat: V2 fields in chara editor (flagged), V2 import, V2 export (with V1 fields backfilled)

### DIFF
--- a/common/characters.ts
+++ b/common/characters.ts
@@ -1,4 +1,5 @@
 import { AppSchema } from '../srv/db/schema'
+import { nativeToCharacterBook } from './memory'
 
 export const defaultChars = {
   Robot: {
@@ -23,4 +24,107 @@ export const defaultChars = {
     AppSchema.Character,
     'name' | 'persona' | 'sampleChat' | 'scenario' | 'greeting'
   >
+}
+
+export function exportCharacter(char: AppSchema.Character, target: 'tavern' | 'ooba') {
+  switch (target) {
+    case 'tavern': {
+      return {
+        // Backfilled V1 fields
+        // TODO: 2 months after V2 adoption, change every field with "This is
+        // a V2 card, update your frontend <link_with_more_details_goes_here>"
+        name: char.name,
+        first_mes: char.greeting,
+        scenario: char.scenario,
+        description: formatCharacter(char.name, char.persona),
+        personality: '',
+        mes_example: char.sampleChat,
+
+        // V2 data
+        spec: 'chara_card_v2',
+        spec_version: '2.0',
+        data: {
+          name: char.name,
+          first_mes: char.greeting,
+          scenario: char.scenario,
+          description: formatCharacter(char.name, char.persona),
+          personality: '',
+          mes_example: char.sampleChat,
+
+          // new v2 fields
+          creator_notes: char.description ?? '',
+          system_prompt: char.systemPrompt ?? '',
+          post_history_instructions: char.postHistoryInstructions ?? '',
+          alternate_greetings: char.alternateGreetings ?? [],
+          character_book: char.characterBook
+            ? nativeToCharacterBook(char.characterBook)
+            : undefined,
+          tags: char.tags ?? [],
+          creator: char.creator ?? '',
+          character_version: char.characterVersion ?? '',
+          extensions: {
+            ...(char.extensions ?? {}),
+            agnai: {
+              voice: char.voice,
+              persona: char.persona,
+            },
+          },
+        },
+      }
+    }
+
+    case 'ooba': {
+      return {
+        char_name: char.name,
+        char_greeting: char.greeting,
+        world_scenario: char.scenario,
+        char_persona: formatCharacter(char.name, char.persona),
+        example_dialogue: char.sampleChat,
+      }
+    }
+  }
+}
+
+export function formatCharacter(
+  name: string,
+  persona: AppSchema.Persona,
+  kind?: AppSchema.Persona['kind']
+) {
+  switch (kind || persona.kind) {
+    case 'wpp': {
+      const attrs = Object.entries(persona.attributes)
+        .map(([key, values]) => `${key}(${values.map(quote).join(' + ')})`)
+        .join('\n')
+
+      return [`[character("${name}") {`, attrs, '}]'].join('\n')
+    }
+
+    case 'sbf': {
+      const attrs = Object.entries(persona.attributes).map(
+        ([key, values]) => `${key}: ${values.map(quote).join(', ')}`
+      )
+
+      return `[ character: "${name}"; ${attrs.join('; ')} ]`
+    }
+
+    case 'boostyle': {
+      const attrs = Object.values(persona.attributes).reduce(
+        (prev, curr) => {
+          prev.push(...curr)
+          return prev
+        },
+        [name]
+      )
+      return attrs.join(' + ')
+    }
+
+    case 'text': {
+      const text = persona.attributes.text?.[0]
+      return text || ''
+    }
+  }
+}
+
+function quote(str: string) {
+  return `"${str}"`
 }

--- a/common/memory.ts
+++ b/common/memory.ts
@@ -3,6 +3,8 @@ import { defaultPresets } from './presets'
 import { BOT_REPLACE, SELF_REPLACE } from './prompt'
 import { Encoder } from './tokenize'
 
+export const BUNDLED_CHARACTER_BOOK_ID = '__bundled__characterbook__'
+
 export type MemoryOpts = {
   user: AppSchema.User
   chat: AppSchema.Chat
@@ -25,13 +27,43 @@ type Match = {
 
   /** The position within the prompt that it was found. Larger means closer to the end */
   index: number
-
   entry: AppSchema.MemoryEntry
-
   tokens: number
-
   text: string
 }
+
+export type CharacterBook = {
+  name?: string
+  description?: string
+  scan_depth?: number /** agnai: "Memory: Chat History Depth" */
+  token_budget?: number /** agnai: "Memory: Context Limit" */
+  recursive_scanning?: boolean /** no agnai equivalent. whether entry content can trigger other entries */
+  extensions: Record<string, any>
+  entries: Array<{
+    keys: Array<string>
+    content: string
+    extensions: Record<string, any>
+    enabled: boolean
+    insertion_order: number /** if two entries inserted, lower "insertion order" = inserted higher */
+    case_sensitive?: boolean
+
+    // FIELDS WITH NO CURRENT EQUIVALENT IN SILLY
+    name?: string /** not used in prompt engineering */
+    priority?: number /** if token budget reached, lower priority value = discarded first */
+
+    // FIELDS WITH NO CURRENT EQUIVALENT IN AGNAI
+    id?: number /** not used in prompt engineering */
+    comment?: string /** not used in prompt engineering */
+    selective?: boolean /** if `true`, require a key from both `keys` and `secondary_keys` to trigger the entry */
+    secondary_keys?: Array<string> /** see field `selective`. ignored if selective == false */
+    constant?: boolean /** if true, always inserted in the prompt (within budget limit) */
+    position?:
+      | 'before_char'
+      | 'after_char' /** whether the entry is placed before or after the character defs */
+  }>
+}
+
+type CharacterBookEntry = CharacterBook['entries'][number]
 
 /**
  * When determine the insertion order of an entry:
@@ -123,42 +155,58 @@ function prep(str: string, safe?: boolean) {
   return next.toLowerCase().replace(/\-/g, '\\-')
 }
 
-export const BUNDLED_CHARACTER_BOOK_ID = 'characterBook3872489385'
-
-export const characterBookToAgnaiMemory = (cb: CharacterBook): AppSchema.MemoryBook => ({
-  kind: 'memory',
-  _id: BUNDLED_CHARACTER_BOOK_ID,
-  name: cb.name ?? 'Character book',
-  description: cb.description ?? '',
-  userId: 'characterBook',
-  entries: cb.entries.map((cbEntry) => ({
-    name: cbEntry.name ?? 'Unnamed',
-    entry: cbEntry.content,
-    keywords: cbEntry.keys,
-    priority: cbEntry.priority ?? 100,
-    weight: cbEntry.insertion_order ?? 100,
-    enabled: cbEntry.enabled,
+export function characterBookToNative(cb: CharacterBook): AppSchema.MemoryBook {
+  return {
+    kind: 'memory',
+    _id: BUNDLED_CHARACTER_BOOK_ID,
+    name: cb.name ?? 'Character book',
+    description: cb.description ?? '',
+    userId: 'characterBook',
+    entries: cb.entries.map(memoryEntryToNative),
 
     // currently unsupported V2 fields which are here so that we don't destroy them
-    id: cbEntry.id,
-    comment: cbEntry.comment,
-    selective: cbEntry.selective,
-    secondaryKeys: cbEntry.secondary_keys,
-    constant: cbEntry.constant,
-    position: cbEntry.position,
-  })),
+    scanDepth: cb.scan_depth,
+    tokenBudget: cb.token_budget,
+    recursiveScanning: cb.recursive_scanning,
+    extensions: cb.extensions,
+  }
+}
 
-  // currently unsupported V2 fields which are here so that we don't destroy them
-  scanDepth: cb.scan_depth,
-  tokenBudget: cb.token_budget,
-  recursiveScanning: cb.recursive_scanning,
-  extensions: cb.extensions,
-})
+export function nativeToCharacterBook(memory: AppSchema.MemoryBook): CharacterBook {
+  return {
+    name: memory.name,
+    description: memory.description,
+    entries: memory.entries.map(nativeToMemoryEntry),
 
-export const agnaiMemoryToCharacterBook = (memory: AppSchema.MemoryBook): CharacterBook => ({
-  name: memory.name,
-  description: memory.description,
-  entries: memory.entries.map((memoryEntry) => ({
+    // currently unsupported V2 fields which are here so that we don't destroy them
+    extensions: memory.extensions ?? {},
+    scan_depth: memory.scanDepth,
+    token_budget: memory.tokenBudget,
+    recursive_scanning: memory.recursiveScanning,
+  }
+}
+
+function memoryEntryToNative(entry: CharacterBookEntry): AppSchema.MemoryEntry {
+  return {
+    name: entry.name ?? 'Unnamed',
+    entry: entry.content,
+    keywords: entry.keys,
+    priority: entry.priority ?? 100,
+    weight: entry.insertion_order ?? 100,
+    enabled: entry.enabled,
+
+    // currently unsupported V2 fields which are here so that we don't destroy them
+    id: entry.id,
+    comment: entry.comment,
+    selective: entry.selective,
+    secondaryKeys: entry.secondary_keys,
+    constant: entry.constant,
+    position: entry.position,
+  }
+}
+
+function nativeToMemoryEntry(memoryEntry: AppSchema.MemoryEntry): CharacterBookEntry {
+  return {
     keys: memoryEntry.keywords,
     content: memoryEntry.entry,
     extensions: {},
@@ -174,40 +222,5 @@ export const agnaiMemoryToCharacterBook = (memory: AppSchema.MemoryBook): Charac
     secondary_keys: memoryEntry.secondaryKeys,
     constant: memoryEntry.constant,
     position: memoryEntry.position,
-  })),
-
-  // currently unsupported V2 fields which are here so that we don't destroy them
-  extensions: memory.extensions ?? {},
-  scan_depth: memory.scanDepth,
-  token_budget: memory.tokenBudget,
-  recursive_scanning: memory.recursiveScanning,
-})
-
-export type CharacterBook = {
-  name?: string
-  description?: string
-  scan_depth?: number // agnai: "Memory: Chat History Depth"
-  token_budget?: number // agnai: "Memory: Context Limit"
-  recursive_scanning?: boolean // no agnai equivalent. whether entry content can trigger other entries
-  extensions: Record<string, any>
-  entries: Array<{
-    keys: Array<string>
-    content: string
-    extensions: Record<string, any>
-    enabled: boolean
-    insertion_order: number // if two entries inserted, lower "insertion order" = inserted higher
-    case_sensitive?: boolean
-
-    // FIELDS WITH NO CURRENT EQUIVALENT IN SILLY
-    name?: string // not used in prompt engineering
-    priority?: number // if token budget reached, lower priority value = discarded first
-
-    // FIELDS WITH NO CURRENT EQUIVALENT IN AGNAI
-    id?: number // not used in prompt engineering
-    comment?: string // not used in prompt engineering
-    selective?: boolean // if `true`, require a key from both `keys` and `secondary_keys` to trigger the entry
-    secondary_keys?: Array<string> // see field `selective`. ignored if selective == false
-    constant?: boolean // if true, always inserted in the prompt (within budget limit)
-    position?: 'before_char' | 'after_char' // whether the entry is placed before or after the character defs
-  }>
+  }
 }

--- a/common/util.ts
+++ b/common/util.ts
@@ -7,3 +7,4 @@ export function toArray<T>(values?: T | T[]): T[] {
 export function wait(secs: number) {
   return new Promise((res) => setTimeout(res, secs * 1000))
 }
+export const isObject = (val: unknown) => Object.prototype.toString.call(val) === '[object Object]'

--- a/srv/api/character.ts
+++ b/srv/api/character.ts
@@ -57,17 +57,21 @@ const createCharacter = handle(async (req) => {
   const body = handleForm(req, newCharacterValidator)
   const persona = JSON.parse(body.persona) as AppSchema.Persona
   assertValid(personaValidator, persona)
+
   const voice = parseAndValidateVoice(body.voice)
   const tags = toArray(body.tags)
   const alternateGreetings = body.alternateGreetings ? toArray(body.alternateGreetings) : undefined
+
   const characterBook = body.characterBook ? JSON.parse(body.characterBook) : undefined
   if (characterBook !== undefined) {
     assertValid(validBook, characterBook)
   }
+
   const extensions = body.extensions ? JSON.parse(body.extensions) : undefined
   if (!isObject(extensions) && extensions !== undefined) {
     throw new StatusError('Character `extensions` field must be an object or undefined.', 400)
   }
+
   const char = await store.characters.createCharacter(req.user?.userId!, {
     name: body.name,
     persona,

--- a/srv/api/character.ts
+++ b/srv/api/character.ts
@@ -10,6 +10,8 @@ import { CharacterUpdate } from '../db/characters'
 import { getVoiceService } from '../voice'
 import { generateImage } from '../image'
 import { v4 } from 'uuid'
+import { validBook } from './memory'
+import { isObject } from '/common/util'
 
 const router = Router()
 
@@ -25,6 +27,15 @@ const characterValidator = {
   favorite: 'boolean?',
   voice: 'string?',
   tags: 'string?',
+
+  // v2 fields start here
+  alternateGreetings: 'string?',
+  characterBook: 'string?',
+  extensions: 'string?',
+  systemPrompt: 'string?',
+  postHistoryInstructions: 'string?',
+  creator: 'string?',
+  characterVersion: 'string?',
 } as const
 
 const newCharacterValidator = {
@@ -48,7 +59,15 @@ const createCharacter = handle(async (req) => {
   assertValid(personaValidator, persona)
   const voice = parseAndValidateVoice(body.voice)
   const tags = toArray(body.tags)
-
+  const alternateGreetings = body.alternateGreetings ? toArray(body.alternateGreetings) : undefined
+  const characterBook = body.characterBook ? JSON.parse(body.characterBook) : undefined
+  if (characterBook !== undefined) {
+    assertValid(validBook, characterBook)
+  }
+  const extensions = body.extensions ? JSON.parse(body.extensions) : undefined
+  if (!isObject(extensions) && extensions !== undefined) {
+    throw new StatusError('Character `extensions` field must be an object or undefined.', 400)
+  }
   const char = await store.characters.createCharacter(req.user?.userId!, {
     name: body.name,
     persona,
@@ -61,6 +80,12 @@ const createCharacter = handle(async (req) => {
     favorite: false,
     voice,
     tags,
+    alternateGreetings,
+    characterBook,
+    systemPrompt: body.systemPrompt,
+    postHistoryInstructions: body.postHistoryInstructions,
+    creator: body.creator,
+    characterVersion: body.characterVersion,
   })
 
   const filename = await entityUpload(
@@ -86,6 +111,16 @@ const editCharacter = handle(async (req) => {
   const id = req.params.id
   const body = handleForm(req, characterValidator)
 
+  const alternateGreetings = body.alternateGreetings ? toArray(body.alternateGreetings) : undefined
+  const characterBook = body.characterBook ? JSON.parse(body.characterBook) : undefined
+  if (characterBook !== undefined) {
+    assertValid(validBook, characterBook)
+  }
+  const extensions = body.extensions ? JSON.parse(body.extensions) : undefined
+  if (!isObject(extensions) && extensions !== undefined) {
+    throw new StatusError('Character `extensions` field must be an object or undefined.', 400)
+  }
+
   const update: CharacterUpdate = {
     name: body.name,
     description: body.description,
@@ -93,6 +128,12 @@ const editCharacter = handle(async (req) => {
     greeting: body.greeting,
     scenario: body.scenario,
     sampleChat: body.sampleChat,
+    alternateGreetings,
+    characterBook: characterBook ?? null,
+    systemPrompt: body.systemPrompt,
+    postHistoryInstructions: body.postHistoryInstructions,
+    creator: body.creator,
+    characterVersion: body.characterVersion,
   }
 
   if (body.persona) {

--- a/srv/api/memory/index.ts
+++ b/srv/api/memory/index.ts
@@ -17,7 +17,7 @@ const validEntry = {
   keywords: ['string'],
 } as const
 
-const validBook = {
+export const validBook = {
   name: 'string',
   description: 'string?',
   entries: [validEntry],

--- a/srv/db/characters.ts
+++ b/srv/db/characters.ts
@@ -17,6 +17,13 @@ export type CharacterUpdate = Partial<
     | 'tags'
     | 'favorite'
     | 'voice'
+    | 'alternateGreetings'
+    | 'characterBook'
+    | 'extensions'
+    | 'systemPrompt'
+    | 'postHistoryInstructions'
+    | 'creator'
+    | 'characterVersion'
   >
 >
 
@@ -35,6 +42,13 @@ export async function createCharacter(
     | 'tags'
     | 'favorite'
     | 'voice'
+    | 'alternateGreetings'
+    | 'characterBook'
+    | 'extensions'
+    | 'systemPrompt'
+    | 'postHistoryInstructions'
+    | 'creator'
+    | 'characterVersion'
   >
 ) {
   const newChar: AppSchema.Character = {

--- a/srv/db/schema.ts
+++ b/srv/db/schema.ts
@@ -178,6 +178,15 @@ export namespace AppSchema {
     favorite?: boolean
 
     voice?: VoiceSettings
+
+    // v2 stuff
+    alternateGreetings?: string[]
+    characterBook?: MemoryBook
+    extensions?: Record<string, any>
+    systemPrompt?: string
+    postHistoryInstructions?: string
+    creator?: string
+    characterVersion?: string
   }
 
   export interface ChatInvite {
@@ -276,6 +285,12 @@ export namespace AppSchema {
     description?: string
     userId: string
     entries: MemoryEntry[]
+
+    // currently unsupported V2 fields which are here so that we don't destroy them
+    scanDepth?: number
+    tokenBudget?: number
+    recursiveScanning?: boolean
+    extensions?: Record<string, any>
   }
 
   export interface MemoryEntry {
@@ -294,6 +309,14 @@ export namespace AppSchema {
     weight: number
 
     enabled: boolean
+
+    // currently unsupported V2 fields which are here so that we don't destroy them
+    id?: number
+    comment?: string
+    selective?: boolean
+    secondaryKeys?: Array<string>
+    constant?: boolean
+    position?: 'before_char' | 'after_char'
   }
 
   export interface VoiceDefinition {

--- a/web/Navigation.tsx
+++ b/web/Navigation.tsx
@@ -70,7 +70,10 @@ const Navigation: Component = () => {
               />
               <div class="ellipsis flex cursor-pointer items-center justify-end rounded-lg bg-[var(--bg-700)] px-2 py-1">
                 <div class="ellipsis flex flex-col">
-                  <span>{chars.impersonating?.name || user.profile?.handle}</span>
+                  <span>
+                    {chars.impersonating?.name || user.profile?.handle}
+                    {state.flags.charv2 ? ' (v2)' : ''}
+                  </span>
                 </div>
                 <Show when={!!chars.impersonating}>
                   <VenetianMask size={16} class="ml-2" />

--- a/web/pages/Character/CharacterList.tsx
+++ b/web/pages/Character/CharacterList.tsx
@@ -604,7 +604,7 @@ export const DownloadModal: Component<{
     { equals: false }
   )
 
-  const [format, setFormat] = createSignal('native')
+  const [format, setFormat] = createSignal('tavern')
   const [fileType, setFileType] = createSignal<CharacterFileType>('png')
   const [schema, setSchema] = createSignal(opts()[0].value)
 
@@ -630,8 +630,11 @@ export const DownloadModal: Component<{
             fieldName="app"
             value={format()}
             items={[
-              { value: 'native', label: 'Agnaistic' },
               { value: 'tavern', label: 'TavernAI' },
+              // TODO: We don't need to support exporting in Agnaistic format
+              // once we fully support Chara Card V2. We just need to put
+              // Agnai-specific fields in the `extensions` prop.
+              { value: 'native', label: 'Agnaistic' },
               { value: 'ooba', label: 'Textgen' },
             ]}
             onChange={(item) => setFormat(item.value)}

--- a/web/pages/Character/CharacterList.tsx
+++ b/web/pages/Character/CharacterList.tsx
@@ -42,7 +42,7 @@ import { getAssetUrl, safeLocalStorage, setComponentPageTitle } from '../../shar
 import { DropMenu } from '../../shared/DropMenu'
 import Button from '../../shared/Button'
 import Modal from '../../shared/Modal'
-import { exportCharacter } from '../../../common/prompt'
+import { exportCharacter } from '../../../common/characters'
 import Loading from '../../shared/Loading'
 import Divider from '../../shared/Divider'
 import CreateChatModal from './CreateChat'

--- a/web/pages/Character/CreateCharacter.tsx
+++ b/web/pages/Character/CreateCharacter.tsx
@@ -535,8 +535,10 @@ const MemoryBookPicker: Component<{
   setCharacterBook: (newVal: AppSchema.MemoryBook | undefined) => void
 }> = (props) => {
   const memory = memoryStore()
-  const bookOptions = () => memory.books.list.map((book) => ({ label: book.name, value: book._id }))
-  const NONE_VALUE = 'noneValue786845648'
+  const bookOptions = createMemo(() =>
+    memory.books.list.map((book) => ({ label: book.name, value: book._id }))
+  )
+  const NONE_VALUE = '__bundled__none__'
   const onChange = (option: Option) => {
     if (option.value == NONE_VALUE) {
       props.setCharacterBook(undefined)

--- a/web/pages/Character/ImportCharacter.tsx
+++ b/web/pages/Character/ImportCharacter.tsx
@@ -6,8 +6,8 @@ import FileInput, { FileInputResult, getFileAsString } from '../../shared/FileIn
 import Modal from '../../shared/Modal'
 import { characterStore, NewCharacter, toastStore } from '../../store'
 import { extractCardData } from './card-utils'
-import { characterBookToAgnaiMemory } from '/common/memory'
-import { formatCharacter } from '/common/prompt'
+import { characterBookToNative } from '/common/memory'
+import { formatCharacter } from '/common/characters'
 import AvatarIcon from '/web/shared/AvatarIcon'
 
 const SUPPORTED_FORMATS = 'Agnaistic, CAI, TavernAI, TextGen, Pygmalion'
@@ -252,7 +252,7 @@ function jsonToCharacter(json: any): NewCharacter {
     originalAvatar: undefined,
     alternateGreetings: json.data.alternate_greetings,
     characterBook: json.data.character_book
-      ? characterBookToAgnaiMemory(json.data.character_book)
+      ? characterBookToNative(json.data.character_book)
       : undefined,
     extensions: json.data.extensions,
     systemPrompt: json.data.system_prompt,

--- a/web/shared/PersonaAttributes.tsx
+++ b/web/shared/PersonaAttributes.tsx
@@ -52,16 +52,12 @@ const PersonaAttributes: Component<{
     <>
       <Show when={!props.hideLabel}>
         <FormLabel
-          label="Persona Attributes"
+          label="Personality"
           helperText={
             <>
               <span>
-                The attributes of your persona. See the link at the top of the page for more
-                information.
-                <br />
                 <Show when={!props.plainText}>
-                  It is highly recommended to always include the attributes <b>mind</b> and{' '}
-                  <b>personality</b>.<br />
+                  It is highly recommended to always include the <b>personality</b> attribute.
                   <b>Example attributes</b>: mind, personality, appearance, likes, dislikes, hates,
                   loves.
                 </Show>

--- a/web/shared/PersonaAttributes.tsx
+++ b/web/shared/PersonaAttributes.tsx
@@ -69,7 +69,12 @@ const PersonaAttributes: Component<{
       <Show when={props.plainText}>
         <div>
           <TextInput fieldName="attr-key.0" value="text" class="hidden" />
-          <TextInput fieldName="attr-value.0" value={props.value?.text?.[0]} isMultiline />
+          <TextInput
+            fieldName="attr-value.0"
+            value={props.value?.text?.[0]}
+            isMultiline
+            placeholder="{{char}}'s name is Johnny Bravo, a tall, muscular, handsome man who is very flirtatious towards {{user}}."
+          />
         </div>
       </Show>
       <Show when={!props.plainText}>

--- a/web/shared/TextInput.tsx
+++ b/web/shared/TextInput.tsx
@@ -20,7 +20,9 @@ const TextInput: Component<{
   onKeyUp?: (
     ev: KeyboardEvent & { target: Element; currentTarget: HTMLInputElement | HTMLTextAreaElement }
   ) => void
-  onChange?: (ev: Event & { target: Element; currentTarget: HTMLInputElement }) => void
+  onChange?: (
+    ev: Event & { target: Element; currentTarget: HTMLInputElement | HTMLTextAreaElement }
+  ) => void
 
   service?: AIAdapter
   aiSetting?: keyof PresetAISettings
@@ -93,6 +95,7 @@ const TextInput: Component<{
           }
           disabled={props.disabled}
           onKeyUp={(ev) => props.onKeyUp?.(ev)}
+          onchange={(ev) => props.onChange?.(ev)}
           onInput={resize}
         />
       </Show>

--- a/web/shared/TextInput.tsx
+++ b/web/shared/TextInput.tsx
@@ -76,7 +76,7 @@ const TextInput: Component<{
             value={value()}
             class={'form-field focusable-field w-full rounded-xl px-4 py-2 ' + props.class}
             onkeyup={(ev) => props.onKeyUp?.(ev)}
-            onchange={(ev) => props.onChange?.(ev)}
+            onChange={(ev) => props.onChange?.(ev)}
             disabled={props.disabled}
             pattern={props.pattern}
           />

--- a/web/shared/util.ts
+++ b/web/shared/util.ts
@@ -467,3 +467,18 @@ export function appendFormOptional(
   if (stringify) form.append(key, stringify(value))
   else form.append(key, value as string | File)
 }
+
+/**
+ * Like `appendFormOptional`, but does append the value if it is an empty string.
+ * This might be what we want `appendFormOptional` to be, but I'm scared of breaking things.
+ */
+export function appendFormOptional_<T>(
+  form: FormData,
+  key: string,
+  value: T,
+  stringify?: (v: T) => string
+) {
+  if (value === null || value === undefined) return
+  if (stringify) form.append(key, stringify(value))
+  else form.append(key, value as string | File)
+}

--- a/web/store/character.ts
+++ b/web/store/character.ts
@@ -26,7 +26,21 @@ type CharacterState = {
 }
 
 export type NewCharacter = UpdateCharacter &
-  Pick<AppSchema.Character, 'name' | 'greeting' | 'scenario' | 'sampleChat' | 'persona'> & {
+  Pick<
+    AppSchema.Character,
+    | 'name'
+    | 'greeting'
+    | 'scenario'
+    | 'sampleChat'
+    | 'persona'
+    | 'alternateGreetings'
+    | 'characterBook'
+    | 'extensions'
+    | 'systemPrompt'
+    | 'postHistoryInstructions'
+    | 'creator'
+    | 'characterVersion'
+  > & {
     originalAvatar: any
   }
 

--- a/web/store/data/chars.ts
+++ b/web/store/data/chars.ts
@@ -3,7 +3,7 @@ import { AppSchema } from '../../../srv/db/schema'
 import { api, isLoggedIn } from '../api'
 import { NewCharacter, UpdateCharacter } from '../character'
 import { loadItem, localApi } from './storage'
-import { appendFormOptional } from '/web/shared/util'
+import { appendFormOptional, appendFormOptional_ } from '/web/shared/util'
 
 export const charsApi = {
   getCharacters,
@@ -103,6 +103,14 @@ export async function editCharacter(charId: string, { avatar: file, ...char }: U
     appendFormOptional(form, 'sampleChat', char.sampleChat)
     appendFormOptional(form, 'voice', JSON.stringify(char.voice))
     appendFormOptional(form, 'avatar', file)
+    // v2 fields start here
+    appendFormOptional(form, 'alternateGreetings', char.alternateGreetings, JSON.stringify)
+    appendFormOptional(form, 'characterBook', char.characterBook, JSON.stringify)
+    appendFormOptional(form, 'extensions', char.extensions, JSON.stringify)
+    appendFormOptional_(form, 'systemPrompt', char.systemPrompt)
+    appendFormOptional_(form, 'postHistoryInstructions', char.postHistoryInstructions)
+    appendFormOptional_(form, 'creator', char.creator)
+    appendFormOptional_(form, 'characterVersion', char.characterVersion)
 
     const res = await api.upload(`/character/${charId}`, form)
     return res
@@ -158,6 +166,14 @@ export async function createCharacter(char: NewCharacter) {
     appendFormOptional(form, 'avatar', char.avatar)
     appendFormOptional(form, 'originalAvatar', char.originalAvatar)
 
+    // v2 fields start here
+    appendFormOptional(form, 'alternateGreetings', char.alternateGreetings, JSON.stringify)
+    appendFormOptional(form, 'characterBook', char.characterBook, JSON.stringify)
+    appendFormOptional(form, 'extensions', char.extensions, JSON.stringify)
+    appendFormOptional(form, 'systemPrompt', char.systemPrompt)
+    appendFormOptional(form, 'postHistoryInstructions', char.postHistoryInstructions)
+    appendFormOptional(form, 'creator', char.creator)
+    appendFormOptional(form, 'characterVersion', char.characterVersion)
     const res = await api.upload<AppSchema.Character>(`/character`, form)
     return res
   }


### PR DESCRIPTION
addresses part of #330 

- When the V2 flag is active (type `flag('charv2')`), the character creator/editor will now show card V2 fields (NOTE: It is not possible yet to edit a Character Book that was bundled with a downloaded character card, in any way. You can only swap it out for an Agnai Memory Book.
- Regardless of flag, it is now possible to import V2 cards
- Regardless of flag, exporting in Tavern format will export as a V2 card with V1 fields backfilled. Agnai voice setting is saved under "agnai" extension.
- Tavern is now the default export format. The only data lost upon converting Agnai cards to Tavern is creation date, update date, and favorite status, so after field testing we might want to drop support for exporting in Agnai format. 
- Plain text is now the default Persona format
- Native memory book has been extended to include Character Book spec fields. We don't need to *use* them, we just need to *not destroy* them.

V2 fields are NOT yet used in actual chats, they're only importable/modifiable/exportable.

Some QA done by me but further QA desirable.