### PR TITLE
NovelAI Clio generation fixes

### DIFF
--- a/common/adapters.ts
+++ b/common/adapters.ts
@@ -174,7 +174,7 @@ export const adapterSettings: {
   temp: ['kobold', 'novel', 'ooba', 'horde', 'luminai', 'openai', 'scale', 'claude'],
   maxTokens: AI_ADAPTERS.slice(),
   maxContextLength: AI_ADAPTERS.slice(),
-  gaslight: ['openai', 'scale', 'kobold', 'claude', 'ooba'],
+  gaslight: ['openai', 'novel', 'scale', 'kobold', 'claude', 'ooba'],
   antiBond: ['openai', 'claude', 'scale'],
   ultimeJailbreak: ['openai', 'claude', 'kobold'],
   topP: ['horde', 'kobold', 'claude', 'ooba', 'openai', 'novel', 'luminai'],

--- a/common/adapters.ts
+++ b/common/adapters.ts
@@ -174,7 +174,7 @@ export const adapterSettings: {
   temp: ['kobold', 'novel', 'ooba', 'horde', 'luminai', 'openai', 'scale', 'claude'],
   maxTokens: AI_ADAPTERS.slice(),
   maxContextLength: AI_ADAPTERS.slice(),
-  gaslight: ['openai', 'novel', 'scale', 'kobold', 'claude', 'ooba'],
+  gaslight: ['openai', 'novel', 'scale', 'kobold', 'claude', 'ooba', 'goose'],
   antiBond: ['openai', 'claude', 'scale'],
   ultimeJailbreak: ['openai', 'claude', 'kobold'],
   topP: ['horde', 'kobold', 'claude', 'ooba', 'openai', 'novel', 'luminai'],

--- a/common/default-preset.ts
+++ b/common/default-preset.ts
@@ -79,8 +79,15 @@ const builtinPresets = {
     topP: 0.95,
     topA: 0.075,
     order: [1, 3, 4, 0, 2],
-    useGaslight: false,
     streamResponse: false,
+    useGaslight: true,
+    gaslight: `{{char}} Memory: {{memory}}
+Description of {{char}}: {{personality}}
+[ Title: Dialogue between {{char}} and {{user}}; Tags: conversation; Genre: online roleplay ]
+This is how the character speaks:
+{{example_dialogue}}
+***
+Summary: {{scenario}}`,
   },
   novel_20BC: {
     name: '20BC+',

--- a/common/default-preset.ts
+++ b/common/default-preset.ts
@@ -84,8 +84,7 @@ const builtinPresets = {
     gaslight: `{{char}} Memory: {{memory}}
 Description of {{char}}: {{personality}}
 [ Title: Dialogue between {{char}} and {{user}}; Tags: conversation; Genre: online roleplay ]
-This is how the character speaks:
-{{example_dialogue}}
+This is how the character speaks:{{example_dialogue}}
 ***
 Summary: {{scenario}}`,
   },

--- a/srv/adapter/generate.ts
+++ b/srv/adapter/generate.ts
@@ -148,7 +148,7 @@ export async function createTextStreamV2(
     lines: opts.lines,
     isThirdParty,
     replyAs: opts.replyAs,
-    characters: opts.characters,
+    characters: Object.assign(opts.characters, { impersonated: opts.impersonate }),
     impersonate: opts.impersonate,
   })
 

--- a/srv/adapter/novel.ts
+++ b/srv/adapter/novel.ts
@@ -57,13 +57,15 @@ export const handleNovel: ModelAdapter = async function* ({
 
   const model = opts.gen.novelModel || user.novelModel || NOVEL_MODELS.euterpe
 
+  const processedPrompt = processNovelAIPrompt(prompt)
+
   const body = {
     model,
-    input: prompt,
+    input: processedPrompt,
     parameters: model === NOVEL_MODELS.clio_v1 ? getClioParams(opts.gen) : { ...base, ...settings },
   }
 
-  const endTokens = ['***', 'Scenario:', '----']
+  const endTokens = ['***', 'Scenario:', '----', '⁂']
 
   log.debug({ ...body, parameters: { ...body.parameters, bad_words_ids: null } }, 'NovelAI payload')
 
@@ -107,7 +109,7 @@ function getClioParams(gen: Partial<AppSchema.GenSettings>) {
   return {
     temperature: gen.temp,
     max_length: gen.maxTokens,
-    min_length: 8,
+    min_length: 1,
     top_k: gen.topK,
     top_p: gen.topP,
     top_a: gen.topA,
@@ -206,4 +208,8 @@ const fullCompletition = async function* (headers: any, body: any, log: AppLog) 
   }
 
   return { tokens: res.body.output }
+}
+
+function processNovelAIPrompt(prompt: string) {
+  return prompt.replace(/^\<START\>$/gm, '***')
 }

--- a/web/pages/Character/CreateCharacter.tsx
+++ b/web/pages/Character/CreateCharacter.tsx
@@ -53,13 +53,21 @@ const options = [
 const CreateCharacter: Component = () => {
   let ref: any
   const nav = useNavigate()
+  const params = useParams<{ editId?: string; duplicateId?: string }>()
+  const [query] = useSearchParams()
+  setComponentPageTitle(
+    params.editId ? 'Edit character' : params.duplicateId ? 'Copy character' : 'Create character'
+  )
+
+  const srcId = createMemo(() => params.editId || params.duplicateId || '')
+  const [image, setImage] = createSignal<string | undefined>()
 
   const memory = memoryStore()
   const flags = settingStore((s) => s.flags)
   const user = userStore((s) => s.user)
   const tagState = tagStore()
   const state = characterStore((s) => {
-    const edit = s.characters.list.find((ch) => ch._id === srcId)
+    const edit = s.characters.list.find((ch) => ch._id === srcId())
     setImage(edit?.avatar)
     return {
       avatar: s.generate,
@@ -69,13 +77,6 @@ const CreateCharacter: Component = () => {
     }
   })
 
-  const params = useParams<{ editId?: string; duplicateId?: string }>()
-  const [query] = useSearchParams()
-  setComponentPageTitle(
-    params.editId ? 'Edit character' : params.duplicateId ? 'Copy character' : 'Create character'
-  )
-
-  const [image, setImage] = createSignal<string | undefined>()
   const [downloaded, setDownloaded] = createSignal<NewCharacter>()
   const [schema, setSchema] = createSignal<AppSchema.Persona['kind'] | undefined>()
   const [tags, setTags] = createSignal(state.edit?.tags)
@@ -89,8 +90,6 @@ const CreateCharacter: Component = () => {
   )
 
   const edit = createMemo(() => state.edit)
-
-  const srcId = params.editId || params.duplicateId || ''
 
   const isExternalBook = createMemo(() =>
     memory.books.list.every((book) => book._id !== state.edit?.characterBook?._id)

--- a/web/shared/GenerationSettings.tsx
+++ b/web/shared/GenerationSettings.tsx
@@ -228,12 +228,12 @@ const PromptSettings: Component<Props> = (props) => {
         label="Use Gaslight"
         helperText={
           <>
+            If this option is enabled, the Gaslight text will be included in the prompt sent to the
+            AI service.
             <p class="font-bold">
               CAUTION: By using the gaslight, you assume full control of the prompt "pre-amble". If
               you do not include the placeholders, they will not be included in the prompt at all.
             </p>
-            If this option is enabled, the Gaslight text will be included in the prompt sent to the
-            AI service. Particularly useful for Scale.
           </>
         }
         value={props.inherit?.useGaslight ?? false}
@@ -244,13 +244,11 @@ const PromptSettings: Component<Props> = (props) => {
 
       <TextInput
         fieldName="gaslight"
-        label="Gaslight Prompt (OpenAI, Scale, Alpaca, LLaMa, Claude)"
         helperText={
           <>
-            How the character definitions are sent to OpenAI. Placeholders:{' '}
-            <code>{'{{char}}'}</code> <code>{'{{user}}'}</code> <code>{'{{personality}}'}</code>{' '}
-            <code>{'{{memory}}'}</code> <code>{'{{scenario}}'}</code>{' '}
-            <code>{'{{example_dialogue}}'}</code>
+            Placeholders: <code>{'{{char}}'}</code> <code>{'{{user}}'}</code>{' '}
+            <code>{'{{personality}}'}</code> <code>{'{{memory}}'}</code>{' '}
+            <code>{'{{scenario}}'}</code> <code>{'{{example_dialogue}}'}</code>
           </>
         }
         placeholder="Be sure to include the placeholders above"

--- a/web/shared/TextInput.tsx
+++ b/web/shared/TextInput.tsx
@@ -51,16 +51,18 @@ const TextInput: Component<{
 
   return (
     <div class={`w-full ${hide()}`}>
-      <Show when={!!props.label}>
+      <Show when={!!props.label || !!props.helperText}>
         <label for={props.fieldName}>
-          <div class={props.helperText ? '' : 'pb-1'}>
-            {props.label}
-            <Show when={props.isMultiline}>
-              <IsVisible onEnter={resize} />
-            </Show>
-          </div>
+          <Show when={!!props.label}>
+            <div class={props.helperText ? '' : 'pb-1'}>
+              {props.label}
+              <Show when={props.isMultiline}>
+                <IsVisible onEnter={resize} />
+              </Show>
+            </div>
+          </Show>
           <Show when={!!props.helperText}>
-            <p class="mt-[-0.125rem] pb-1 text-sm text-[var(--text-700)]">{props.helperText}</p>
+            <p class="mt-[-0.125rem] pb-2 text-sm text-[var(--text-700)]">{props.helperText}</p>
           </Show>
         </label>
       </Show>

--- a/web/shared/adapter.ts
+++ b/web/shared/adapter.ts
@@ -38,15 +38,12 @@ export function getPresetOptions(
   includes: { builtin?: boolean; base?: boolean }
 ) {
   const user = userStore((u) => u.user || { defaultPreset: '' })
-  const presets = userPresets
-    .slice()
-    .map((preset) => ({
-      label: `[${getServiceName(preset.service)}] ${preset.name} ${
-        user.defaultPreset === preset._id ? '(*) ' : ''
-      }`,
-      value: preset._id,
-    }))
-    .sort(sortByLabel)
+  const presets = userPresets.slice().map((preset) => ({
+    label: `[${getServiceName(preset.service)}, Custom] ${preset.name} ${
+      user.defaultPreset === preset._id ? '(*) ' : ''
+    }`,
+    value: preset._id,
+  }))
 
   const defaults = Object.entries(defaultPresets).map(([_id, preset]) => ({
     ...preset,
@@ -55,18 +52,17 @@ export function getPresetOptions(
   }))
 
   if (includes.builtin) {
-    const builtinOptions = defaults
-      .map((preset) => ({
-        label: `[Built-in, ${getServiceName(preset.service)}] ${preset.name} `,
-        value: preset._id,
-      }))
-      .sort(sortByLabel)
+    const builtinOptions = defaults.map((preset) => ({
+      label: `[${getServiceName(preset.service)}, Built-in] ${preset.name}`,
+      value: preset._id,
+    }))
 
     presets.push(...builtinOptions)
   }
 
-  if (includes.base) return BasePresetOptions.concat(presets)
-  return presets
+  if (includes.base) presets.unshift(...BasePresetOptions)
+
+  return presets.sort(sortByLabel)
 }
 
 export function getInitialPresetValue(chat?: AppSchema.Chat) {
@@ -82,9 +78,9 @@ export function getServiceName(service?: AIAdapter) {
 }
 
 export function sortByName(left: { name: string }, right: { name: string }) {
-  return left.name.toLowerCase().localeCompare(right.name.toLowerCase())
+  return left.name.localeCompare(right.name)
 }
 
 export function sortByLabel(left: { label: string }, right: { label: string }) {
-  return left.label.toLowerCase().localeCompare(right.label.toLowerCase())
+  return left.label.localeCompare(right.label)
 }


### PR DESCRIPTION
Small changes that improves Clio's output.

I would think that using "gaslight" for Clio would be better though, because NovelAI has a specific way of building things. Like, the scenario should be after the examples, with the `***` before the scenario text. But I wasn't sure if gaslight was the right way, but otherwise I didn't see how I could make an adapter-specific prompt.

Preferred solution: Adapter-specific prompt builder
Second preferred solution: Gaslight (maybe rename gaslight to prompt template?)
Third preferred solution: It's good enough like this.

Note that you can accept this PR anyway, the gaslight thing can be handled separately.