### PR TITLE
Improved Tag Keybind

### DIFF
--- a/web/shared/TagInput.tsx
+++ b/web/shared/TagInput.tsx
@@ -52,7 +52,7 @@ const TagInput: Component<TagInputProps> = (props) => {
     } else if (e.key === 'Enter' && value !== '' && suggestions().length > 0) {
       e.preventDefault()
       addTag(suggestions()[0])
-    } else if ((e.key === ' ' || e.key == 'Enter') && value !== '') {
+    } else if ((e.key === ',' || e.key == 'Enter') && value !== '') {
       e.preventDefault()
       addTag(value)
     }


### PR DESCRIPTION
This PR aims to provide more natural keyword tagging by separating them with a "," instead of a space. 
This allows the usage of spaces in Tags and simultaneously closes the related issue #383.