### PR TITLE
feat: support card ujb (card ujb replaces preset ujb if card ujb exists)

### DIFF
--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -333,10 +333,9 @@ export function getPromptParts(opts: PromptPartsOptions, lines: string[], encode
 
   const injectOpts = { opts, parts, encoder }
 
-  if (ujb) {
-    parts.ujb = injectPlaceholders(removeUnusedPlaceholders(ujb, parts), injectOpts)
+  if (char.postHistoryInstructions || ujb) {
+    parts.ujb = injectPlaceholders(removeUnusedPlaceholders(char.postHistoryInstructions || ujb!, parts), injectOpts)
   }
-
   parts.gaslight = injectPlaceholders(removeUnusedPlaceholders(gaslight, parts), injectOpts)
 
   /**

--- a/web/pages/Character/CreateCharacter.tsx
+++ b/web/pages/Character/CreateCharacter.tsx
@@ -441,7 +441,7 @@ const CreateCharacter: Component = () => {
           <TextInput
             isMultiline
             fieldName="postHistoryInstructions"
-            label="Post-conversation history instructions(optional)"
+            label="Post-conversation history instructions (optional)"
             helperText={
               <span>Prompt to bundle with your character. Leave empty if you aren't sure.</span>
             }


### PR DESCRIPTION
+ add missing space in UI text

There is currently no way for users to override the V2 card UJB other than editing the card.

**This should probably be merged late in the V2 implementation process, as we're already allowing the import V2 cards, but we're not yet allowing the editing of V2 cards, meaning if a user imports a V2 card they have no way of overriding the card UJB.** Unless we find a simple way to flag this

addresses part of https://github.com/agnaistic/agnai/issues/330
