### PR TITLE
fix: runtime exception in claude adapter

### DIFF
--- a/srv/adapter/claude.ts
+++ b/srv/adapter/claude.ts
@@ -38,7 +38,9 @@ export const handleClaude: ModelAdapter = async function* (opts) {
     `\n\n${char.name}:`,
     `\n\n${username}:`,
     `\n\nSystem:`,
-    ...Object.values(characters || {}).map((ch) => `\n\n${ch.name}:`),
+    ...Object.values(characters || {})
+      .filter((ch) => ch !== undefined)
+      .map((ch) => `\n\n${ch.name}:`),
     ...members.map((member) => `\n\n${member.handle}:`),
   ])
 


### PR DESCRIPTION
The `opts.chars` record got has an `impersonate: undefined` key-value pair in it despite the typescript typing claiming the object is a `Record<string, AppSchema.Character> | undefined` (NOT to be confused with `Record<string, AppSchema.Character | undefined>`).

I don't know how that `impersonate: undefined` key-value pair got in there, if it's supposed to be in there... So I just added an undefined filter. If you understand this better and the way to solve this is different discard this commit.