### PR TITLE
fix: improve ujb efficiency

### DIFF
--- a/srv/adapter/openai.ts
+++ b/srv/adapter/openai.ts
@@ -374,7 +374,6 @@ function toChatCompletionPayload(
 
   if (kind !== 'continue' && kind !== 'summary') {
     const content = getInstruction(opts, encoder)
-    tokens += encoder(content)
     parts.ujb = parts.ujb ? parts.ujb + '\n\n' + content : content
   }
 

--- a/srv/adapter/openai.ts
+++ b/srv/adapter/openai.ts
@@ -375,7 +375,7 @@ function toChatCompletionPayload(
   if (kind !== 'continue' && kind !== 'summary') {
     const content = getInstruction(opts, encoder)
     tokens += encoder(content)
-    history.push({ role: 'system', content })
+    parts.ujb = parts.ujb ? (parts.ujb + '\n\n' + content) : content
   }
 
   if (kind !== 'summary' && parts.ujb) {

--- a/srv/adapter/openai.ts
+++ b/srv/adapter/openai.ts
@@ -375,7 +375,7 @@ function toChatCompletionPayload(
   if (kind !== 'continue' && kind !== 'summary') {
     const content = getInstruction(opts, encoder)
     tokens += encoder(content)
-    parts.ujb = parts.ujb ? (parts.ujb + '\n\n' + content) : content
+    parts.ujb = parts.ujb ? parts.ujb + '\n\n' + content : content
   }
 
   if (kind !== 'summary' && parts.ujb) {


### PR DESCRIPTION
Achieved by inserting the "Reply as ${replyAs.name}" prompt into the same system message as the UJB if it exists.

I've tested this on 10 GPT-4 completions without the change, and 10 completions with the change. 40% rejection rate without the change, 0% with.