### PR TITLE
fix: remove sneaky scrollbar in name/date field on certain browsers

### DIFF
--- a/web/pages/Chat/components/Message.tsx
+++ b/web/pages/Chat/components/Message.tsx
@@ -219,7 +219,7 @@ const SingleMessage: Component<
             </span>
             <span class="flex flex-row justify-between pb-1">
               <span
-                class={`flex min-w-0 shrink flex-col overflow-x-hidden ${nameDateFlexDir()} items-start gap-1 ${nameDateAlignItems()} ${oocNameClass()}`}
+                class={`flex min-w-0 shrink flex-col overflow-hidden ${nameDateFlexDir()} items-start gap-1 ${nameDateAlignItems()} ${oocNameClass()}`}
               >
                 <b
                   class={`text-900 mr-2 max-w-[160px] overflow-hidden  text-ellipsis whitespace-nowrap sm:max-w-[400px] ${nameClasses()}`}


### PR DESCRIPTION
![1687009516](https://github.com/agnaistic/agnai/assets/128472336/c36073f5-0436-4e7b-83c4-345fa114952d)

removes this scrollbar that for some reason doesn't show up for everybody