### PR TITLE
Autoresize chat message input via existing `TextInput` component

### DIFF
--- a/instructions/novel.md
+++ b/instructions/novel.md
@@ -12,7 +12,7 @@
 
 - `console.log(JSON.parse(localStorage.getItem('session')).auth_token)`
 
-4. Copy/paste the resulting output into the `Novel API Key` field
+4. Copy/paste the resulting output into the `Novel API Key` field in your [NovelAI Settings Page](https://agnai.chat/settings?tab=ai&service=novelai)
 
 The API Key will look something like this:
 

--- a/web/pages/Chat/components/InputBar.tsx
+++ b/web/pages/Chat/components/InputBar.tsx
@@ -3,6 +3,7 @@ import { Component, createMemo, createSignal, For, onCleanup, Setter, Show } fro
 import { AppSchema } from '../../../../srv/db/schema'
 import Button from '../../../shared/Button'
 import { DropMenu } from '../../../shared/DropMenu'
+import TextInput from '../../../shared/TextInput'
 import { chatStore, toastStore, userStore } from '../../../store'
 import { msgStore } from '../../../store'
 import { SpeechRecognitionRecorder } from './SpeechRecognitionRecorder'
@@ -138,14 +139,17 @@ const InputBar: Component<{
         </div>
       </Show>
 
-      <textarea
+      <TextInput
+        fieldName="chatInput"
+        isMultiline
         spellcheck
         lang={props.char?.culture}
         ref={ref}
         value={text()}
         placeholder={placeholder()}
-        class="focusable-field h-10 min-h-[40px] w-full rounded-md rounded-r-none px-4 py-2 hover:bg-[var(--bg-800)] active:bg-[var(--bg-800)]"
-        onKeyDown={(ev) => {
+        parentClass="flex w-full"
+        class="h-full rounded-md rounded-r-none hover:bg-[var(--bg-800)] active:bg-[var(--bg-800)]"
+        onKeyUp={(ev) => {
           if (ev.key === 'Enter' && !ev.shiftKey) {
             send()
             ev.preventDefault()
@@ -161,74 +165,72 @@ const InputBar: Component<{
         onSubmit={() => send()}
         cleared={cleared}
       />
-      <div>
-        <button
-          onClick={onButtonClick}
-          class="rounded-l-none rounded-r-md border-l border-[var(--bg-700)] bg-[var(--bg-800)] py-2 px-2 hover:bg-[var(--bg-700)]"
-        >
-          <MoreHorizontal />
-        </button>
-        <DropMenu show={menu()} close={() => setMenu(false)} vert="up" horz="left">
-          <div class="flex w-48 flex-col gap-2 p-2">
-            {/* <Button schema="secondary" class="w-full" onClick={generateSelf} alignLeft>
+      <button
+        onClick={onButtonClick}
+        class="h-full rounded-l-none rounded-r-md border-l border-[var(--bg-700)] bg-[var(--bg-800)] py-2 px-2 hover:bg-[var(--bg-700)]"
+      >
+        <MoreHorizontal />
+      </button>
+      <DropMenu show={menu()} close={() => setMenu(false)} vert="up" horz="left">
+        <div class="flex w-48 flex-col gap-2 p-2">
+          {/* <Button schema="secondary" class="w-full" onClick={generateSelf} alignLeft>
               <MessageCircle size={18} />
               Respond as Me
             </Button> */}
-            <Show when={props.bots.length > 1}>
-              <div>Auto-reply</div>
-              <Button
-                schema="secondary"
-                size="sm"
-                onClick={() => setAutoReplyAs('')}
-                disabled={!chats.replyAs}
-              >
-                None
-              </Button>
-              <For each={props.bots}>
-                {(char) => (
-                  <Show
-                    when={props.chat.characters?.[char._id] || char._id === props.chat.characterId}
-                  >
-                    <Button
-                      schema="secondary"
-                      size="sm"
-                      onClick={() => setAutoReplyAs(char._id)}
-                      disabled={chats.replyAs === char._id}
-                    >
-                      {char.name}
-                    </Button>
-                  </Show>
-                )}
-              </For>
-              <hr />
-            </Show>
-            <Show when={props.showOocToggle}>
-              <Button
-                schema="secondary"
-                size="sm"
-                class="flex items-center justify-between"
-                onClick={toggleOoc}
-              >
-                <div>Stop Bot Reply</div>
-                <Toggle fieldName="ooc" value={props.ooc} onChange={toggleOoc} />
-              </Button>
-            </Show>
-            <Button schema="secondary" class="w-full" onClick={createImage} alignLeft>
-              <ImagePlus size={18} /> Generate Image
+          <Show when={props.bots.length > 1}>
+            <div>Auto-reply</div>
+            <Button
+              schema="secondary"
+              size="sm"
+              onClick={() => setAutoReplyAs('')}
+              disabled={!chats.replyAs}
+            >
+              None
             </Button>
-            <Show when={!!state.lastMsg?.characterId && isOwner()}>
-              <Button schema="secondary" class="w-full" onClick={more} alignLeft>
-                <PlusCircle size={18} /> Generate More
+            <For each={props.bots}>
+              {(char) => (
+                <Show
+                  when={props.chat.characters?.[char._id] || char._id === props.chat.characterId}
+                >
+                  <Button
+                    schema="secondary"
+                    size="sm"
+                    onClick={() => setAutoReplyAs(char._id)}
+                    disabled={chats.replyAs === char._id}
+                  >
+                    {char.name}
+                  </Button>
+                </Show>
+              )}
+            </For>
+            <hr />
+          </Show>
+          <Show when={props.showOocToggle}>
+            <Button
+              schema="secondary"
+              size="sm"
+              class="flex items-center justify-between"
+              onClick={toggleOoc}
+            >
+              <div>Stop Bot Reply</div>
+              <Toggle fieldName="ooc" value={props.ooc} onChange={toggleOoc} />
+            </Button>
+          </Show>
+          <Button schema="secondary" class="w-full" onClick={createImage} alignLeft>
+            <ImagePlus size={18} /> Generate Image
+          </Button>
+          <Show when={!!state.lastMsg?.characterId && isOwner()}>
+            <Button schema="secondary" class="w-full" onClick={more} alignLeft>
+              <PlusCircle size={18} /> Generate More
+            </Button>
+            <Show when={!!props.char?.voice}>
+              <Button schema="secondary" class="w-full" onClick={playVoice} alignLeft>
+                <Megaphone size={18} /> Play Voice
               </Button>
-              <Show when={!!props.char?.voice}>
-                <Button schema="secondary" class="w-full" onClick={playVoice} alignLeft>
-                  <Megaphone size={18} /> Play Voice
-                </Button>
-              </Show>
             </Show>
-          </div>
-        </DropMenu>
-      </div>
+          </Show>
+        </div>
+      </DropMenu>
     </div>
   )
 }

--- a/web/pages/Home/index.tsx
+++ b/web/pages/Home/index.tsx
@@ -44,15 +44,15 @@ const HomePage: Component = () => {
       </Show>
 
       <div class="flex flex-col gap-4 text-lg">
-        <div class="flex justify-center text-6xl">
+        <div class="hidden justify-center text-6xl sm:flex">
           Agn<span class="text-[var(--hl-500)]">ai</span>stic
         </div>
         <Card border>
           <div class="leading-6">
             <b>Agnaistic</b> is a "bring your own AI" chat service. It is completely open-source and
             free to use. You only pay for the third-party AI services that you choose to use. Your
-            conversations are completely private and never shared with anyone unless you invite them
-            to your chat.
+            conversations are completely private and are never shared with anyone unless you invite
+            them to your chat.
           </div>
         </Card>
 
@@ -140,7 +140,7 @@ const HomePage: Component = () => {
           <div class="flex flex-col gap-2 leading-6">
             <p>
               Already have OpenAI, NovelAI, GooseAI, Scale, Claude? Head to the{' '}
-              <A class="link" href="/settings">
+              <A class="link" href="/settings?tab=ai">
                 Settings Page
               </A>{' '}
               and configure your AI service.
@@ -184,7 +184,7 @@ const HordeGuide: Component<{ close: () => void }> = (props) => (
           AI Horde
         </a>
         . Once you have your key, add it to your{' '}
-        <A href="/settings" class="link">
+        <A href="/settings?tab=ai&service=horde" class="link">
           Horde Settings
         </A>
         .
@@ -233,7 +233,7 @@ const OpenAIGuide: Component<{ close: () => void }> = (props) => (
 
       <Card>
         Once you have your API key, head to the{' '}
-        <A class="link" href="/settings">
+        <A class="link" href="/settings?tab=ai&service=openai">
           Settings
         </A>{' '}
         page and set your key in the OpenAI area.

--- a/web/pages/Settings/AISettings.tsx
+++ b/web/pages/Settings/AISettings.tsx
@@ -13,20 +13,25 @@ import OobaAISettings from './components/OobaAISettings'
 import ClaudeSettings from './components/ClaudeSettings'
 import { AutoPreset, getPresetOptions } from '../../shared/adapter'
 import RegisteredSettings from './components/RegisteredSettings'
+import { useSearchParams } from '@solidjs/router'
 
 const AISettings: Component<{
   onHordeWorkersChange: (workers: string[]) => void
   onHordeModelsChange: (models: string[]) => void
 }> = (props) => {
+  const [query] = useSearchParams()
   const state = userStore()
   const cfg = settingStore()
   const presets = presetStore((s) => s.presets.filter((pre) => !!pre.service))
 
   createEffect(() => {
-    setTabs(cfg.config.adapters.map((a) => ADAPTER_LABELS[a] || a))
+    const tabs = cfg.config.adapters.map((a) => ADAPTER_LABELS[a] || a)
+    setTabs(tabs)
+
     if (!ready() && cfg.config.adapters?.length) {
+      const queryTab = tabs.findIndex((label) => label.toLowerCase() === query.service)
       const defaultTab = cfg.config.adapters.indexOf(state.user?.defaultAdapter!)
-      setTab(defaultTab === -1 ? 0 : defaultTab)
+      setTab(queryTab !== -1 ? queryTab : defaultTab === -1 ? 0 : defaultTab)
       setReady(true)
     }
   })

--- a/web/pages/Settings/index.tsx
+++ b/web/pages/Settings/index.tsx
@@ -16,8 +16,9 @@ import { Show } from 'solid-js'
 import { ImageSettings } from './Image/ImageSettings'
 import { VoiceSettings } from './Voice/VoiceSettings'
 import { toArray } from '/common/util'
+import { useSearchParams } from '@solidjs/router'
 
-const settingTabs = {
+const settingTabs: Record<Tab, string> = {
   ai: 'AI Settings',
   ui: 'UI Settings',
   image: 'Image Settings',
@@ -25,13 +26,21 @@ const settingTabs = {
   guest: 'Guest Data',
 }
 
-type Tab = keyof typeof settingTabs
+enum MainTab {
+  ai = 0,
+  ui = 1,
+  image = 2,
+  voice = 3,
+  guest = 4,
+}
+
+type Tab = keyof typeof MainTab
 
 const Settings: Component = () => {
   setComponentPageTitle('Settings')
   const state = userStore()
-
-  const [tab, setTab] = createSignal(0)
+  const [query, _setQuery] = useSearchParams()
+  const [tab, setTab] = createSignal<number>(MainTab[query.tab as Tab] ?? 0)
   const [workers, setWorkers] = createSignal<string[]>(toArray(state.user?.hordeWorkers))
   const [models, setModels] = createSignal<string[]>(toArray(state.user?.hordeModel))
 

--- a/web/shared/TextInput.tsx
+++ b/web/shared/TextInput.tsx
@@ -18,6 +18,8 @@ const TextInput: Component<{
   required?: boolean
   class?: string
   pattern?: string
+  spellcheck?: boolean
+  lang?: string
   parentClass?: string
   tokenCount?: boolean | ((count: number) => void)
   ref?: (ref: any) => void
@@ -26,6 +28,9 @@ const TextInput: Component<{
     ev: KeyboardEvent & { target: Element; currentTarget: HTMLInputElement | HTMLTextAreaElement }
   ) => void
   onChange?: (
+    ev: Event & { target: Element; currentTarget: HTMLInputElement | HTMLTextAreaElement }
+  ) => void
+  onInput?: (
     ev: Event & { target: Element; currentTarget: HTMLInputElement | HTMLTextAreaElement }
   ) => void
 
@@ -53,6 +58,13 @@ const TextInput: Component<{
     props.onChange?.(ev)
   }
 
+  const handleInput = async (
+    ev: Event & { target: Element; currentTarget: HTMLTextAreaElement | HTMLInputElement }
+  ) => {
+    props.onInput?.(ev)
+    if (props.isMultiline) resize()
+  }
+
   const updateCount = async () => {
     if (!props.tokenCount) return
     const tokenizer = await getEncoder()
@@ -66,6 +78,11 @@ const TextInput: Component<{
 
   const resize = () => {
     if (!ref) return
+
+    if (ref.value === '') {
+      ref.style.height = `${MIN_HEIGHT}px`
+      return
+    }
 
     updateCount()
     const next = +ref.scrollHeight < MIN_HEIGHT ? MIN_HEIGHT : ref.scrollHeight
@@ -118,8 +135,11 @@ const TextInput: Component<{
               props.onKeyUp?.(ev)
             }}
             onChange={handleChange}
+            onInput={handleInput}
             disabled={props.disabled}
             pattern={props.pattern}
+            spellcheck={props.spellcheck}
+            lang={props.lang}
             ref={ref}
           />
         }
@@ -136,9 +156,11 @@ const TextInput: Component<{
             props.class
           }
           disabled={props.disabled}
+          spellcheck={props.spellcheck}
+          lang={props.lang}
           onKeyUp={(ev) => props.onKeyUp?.(ev)}
           onchange={handleChange}
-          onInput={resize}
+          onInput={handleInput}
         />
       </Show>
     </div>

--- a/web/shared/TextInput.tsx
+++ b/web/shared/TextInput.tsx
@@ -1,4 +1,4 @@
-import { Component, Show, createMemo, JSX, onMount, createEffect, createSignal, on } from 'solid-js'
+import { Component, Show, createMemo, JSX, onMount, createEffect, createSignal } from 'solid-js'
 import IsVisible from './IsVisible'
 import { AIAdapter, PresetAISettings } from '../../common/adapters'
 import { getAISettingServices } from './util'

--- a/web/shared/TextInput.tsx
+++ b/web/shared/TextInput.tsx
@@ -1,4 +1,4 @@
-import { Component, Show, createMemo, JSX, onMount, createEffect, createSignal } from 'solid-js'
+import { Component, Show, createMemo, JSX, onMount, createEffect, createSignal, on } from 'solid-js'
 import IsVisible from './IsVisible'
 import { AIAdapter, PresetAISettings } from '../../common/adapters'
 import { getAISettingServices } from './util'
@@ -52,6 +52,13 @@ const TextInput: Component<{
     updateCount()
   })
 
+  createEffect(() => {
+    if (props.isMultiline) {
+      value()
+      resize()
+    }
+  })
+
   const handleChange = async (
     ev: Event & { target: Element; currentTarget: HTMLTextAreaElement | HTMLInputElement }
   ) => {
@@ -62,7 +69,6 @@ const TextInput: Component<{
     ev: Event & { target: Element; currentTarget: HTMLTextAreaElement | HTMLInputElement }
   ) => {
     props.onInput?.(ev)
-    if (props.isMultiline) resize()
   }
 
   const updateCount = async () => {
@@ -95,7 +101,6 @@ const TextInput: Component<{
   })
 
   onMount(() => {
-    resize()
     props.ref?.(ref)
   })
 


### PR DESCRIPTION
This PR replaces the fixed height vanilla `<textarea>` element used for chat input with the `<TextArea>` shared component in order to leverage its auto-resizing functionality, making it easier to send longer messages.

## Test Demo
### Web
[vmconnect_2023-06-18_04-51-31.webm](https://github.com/agnaistic/agnai/assets/92774204/4804f395-7dbc-467a-849c-e1c8ae4fd38d)

### Mobile (iOS Safari)
[RPReplay_Final1687082236.webm](https://github.com/agnaistic/agnai/assets/92774204/d30dcf08-7fdc-40ce-adf4-7e9cabf86472)

## Caveats
- There is no limit to how large the `TextInput` can grow which can render the message history inaccessible on mobile if it grows beyond the height of the screen.
  - I considered adding `max-height: 75vh` or something but wasn't sure if that might affect other places using this component so I held off on that for now.
- Previously, `TextInput` would never shrink after growing, which is problematic for chat.  I have adjusted this behavior to instead revert to its minimum height when the content is emptied; I believe this is better for usability than having it constantly grow and shrink as you edit long texts.