### PR TITLE
QA v2 fixes and tweaks

### DIFF
--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -420,9 +420,8 @@ export function getPromptParts(opts: PromptPartsOptions, lines: string[], encode
   const memory = buildMemoryPrompt({ ...opts, books, lines: linesForMemory }, encoder)
   parts.memory = memory?.prompt
 
-  parts.ujb = opts.settings?.ignoreCharacterUjb
-    ? opts.settings?.ultimeJailbreak
-    : replyAs.postHistoryInstructions || opts.settings?.ultimeJailbreak
+  parts.ujb = getFinalUjb(opts.settings?.ignoreCharacterUjb, replyAs.postHistoryInstructions, opts.settings?.ultimeJailbreak)
+
   parts.systemPrompt = opts.settings?.ignoreCharacterSystemPrompt
     ? opts.settings?.systemPrompt
     : replyAs.systemPrompt || opts.settings?.systemPrompt
@@ -430,6 +429,16 @@ export function getPromptParts(opts: PromptPartsOptions, lines: string[], encode
   parts.post = post.map(replace)
 
   return parts
+}
+
+function getFinalUjb(ignoreCharacterUjb?: boolean, charaPhi?: string, userUjb?: string) {
+  if (ignoreCharacterUjb) {
+    return userUjb
+  } else if (charaPhi) {
+    return charaPhi.replace(/{{original}}/gi, userUjb ?? '')
+  } else {
+    return userUjb
+  }
 }
 
 function createPostPrompt(

--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -228,8 +228,8 @@ export function injectPlaceholders(
 
   let prompt = template
     // UJB must be first to replace placeholders within the UJB
+    // Note: for character post-history-instructions, this is off-spec behavior
     .replace(HOLDERS.ujb, opts.settings?.ultimeJailbreak || '')
-    .replace(HOLDERS.systemPrompt, newline(parts.systemPrompt))
     .replace(HOLDERS.sampleChat, newline(sampleChat))
     .replace(HOLDERS.scenario, parts.scenario || '')
     .replace(HOLDERS.memory, newline(parts.memory))
@@ -239,6 +239,8 @@ export function injectPlaceholders(
     .replace(HOLDERS.linebreak, '\n')
     .replace(HOLDERS.chatAge, elapsedSince(opts.chat.createdAt))
     .replace(HOLDERS.idleDuration, elapsedSince(rest.lastMessage || ''))
+    // system prompt should not support other placeholders
+    .replace(HOLDERS.systemPrompt, newline(parts.systemPrompt))
     // All placeholders support {{char}} and {{user}} placeholders therefore these must be last
     .replace(BOT_REPLACE, opts.replyAs.name)
     .replace(SELF_REPLACE, sender)

--- a/web/pages/Chat/UpdateGaslightToUseSystemPromptModal.tsx
+++ b/web/pages/Chat/UpdateGaslightToUseSystemPromptModal.tsx
@@ -112,7 +112,7 @@ const UpdateGaslightToUseSystemPromptModal: Component<{
               value={newSystemPrompt()}
               onChange={(ev) => setNewSystemPrompt(ev.currentTarget.value)}
             />
-            <div class="my-2 text-base">Prompt template (gaslight)</div>
+            <div class="my-2 text-base">Prompt template (formerly gaslight)</div>
             <TextInput
               isMultiline
               fieldName="newGaslight"

--- a/web/pages/Chat/UpdateGaslightToUseSystemPromptModal.tsx
+++ b/web/pages/Chat/UpdateGaslightToUseSystemPromptModal.tsx
@@ -106,6 +106,7 @@ const UpdateGaslightToUseSystemPromptModal: Component<{
           <Show when={settingTab() === 'new'}>
             <div class="my-2 text-base">System prompt</div>
             <TextInput
+              helperText="This field only supports the placeholders {{char}} and {{user}}."
               isMultiline
               fieldName="newSystemPrompt"
               value={newSystemPrompt()}

--- a/web/pages/Chat/UpdateGaslightToUseSystemPromptModal.tsx
+++ b/web/pages/Chat/UpdateGaslightToUseSystemPromptModal.tsx
@@ -35,8 +35,13 @@ const UpdateGaslightToUseSystemPromptModal: Component<{
   )
   const [loadedExtraction, setLoadedExtraction] = createSignal(false)
   createEffect(() => {
-    if (!loadedExtraction() && automaticUpdate().gaslight !== '') {
+    if (
+      !loadedExtraction() &&
+      automaticUpdate().gaslight !== '' &&
+      automaticUpdate().gaslight !== '{{system_prompt}}\n'
+    ) {
       setLoadedExtraction(true)
+      console.log(automaticUpdate())
       setNewSystemPrompt(automaticUpdate().systemPrompt)
       setNewGaslight(automaticUpdate().gaslight)
     }

--- a/web/pages/Chat/UpdateGaslightToUseSystemPromptModal.tsx
+++ b/web/pages/Chat/UpdateGaslightToUseSystemPromptModal.tsx
@@ -41,7 +41,6 @@ const UpdateGaslightToUseSystemPromptModal: Component<{
       automaticUpdate().gaslight !== '{{system_prompt}}\n'
     ) {
       setLoadedExtraction(true)
-      console.log(automaticUpdate())
       setNewSystemPrompt(automaticUpdate().systemPrompt)
       setNewGaslight(automaticUpdate().gaslight)
     }

--- a/web/shared/CreateCharacterForm.tsx
+++ b/web/shared/CreateCharacterForm.tsx
@@ -334,11 +334,11 @@ export const CreateCharacterForm: Component<{
 
             <Card class="flex w-full flex-col">
               <FormLabel
-                label="Description"
+                label="Description / Creator's notes"
                 helperText={
                   <div class="flex flex-col">
                     <span>
-                      A description or label for your character. This is will not influence your
+                      A description, label, or notes for your character. This is will not influence your
                       character in any way.
                     </span>
                     <Show when={canPopulatFields()}>

--- a/web/shared/CreateCharacterForm.tsx
+++ b/web/shared/CreateCharacterForm.tsx
@@ -338,8 +338,8 @@ export const CreateCharacterForm: Component<{
                 helperText={
                   <div class="flex flex-col">
                     <span>
-                      A description, label, or notes for your character. This is will not influence your
-                      character in any way.
+                      A description, label, or notes for your character. This is will not influence
+                      your character in any way.
                     </span>
                     <Show when={canPopulatFields()}>
                       <span>

--- a/web/shared/GenerationSettings.tsx
+++ b/web/shared/GenerationSettings.tsx
@@ -288,7 +288,7 @@ const PromptSettings: Component<Props> = (props) => {
         <FormLabel label="System Prompt" />
         <PromptEditor
           fieldName="systemPrompt"
-          include={['char', 'user', 'chat_age', 'idle_duration']}
+          include={['char', 'user']}
           placeholder="Write {{char}}'s next reply in a fictional chat between {{char}} and {{user}}. Write 1 reply only in internet RP style, italicize actions, and avoid quotation marks. Use markdown. Be proactive, creative, and drive the plot and conversation forward. Write at least 1 paragraph, up to 4. Always stay in character and avoid repetition."
           value={props.inherit?.systemPrompt ?? ''}
           disabled={props.disabled}

--- a/web/shared/PromptEditor/index.tsx
+++ b/web/shared/PromptEditor/index.tsx
@@ -102,7 +102,7 @@ const PromptEditor: Component<
     <div class={`w-full flex-col gap-2 ${hide()}`}>
       <Show when={props.showHelp}>
         <FormLabel
-          label="Prompt Template (aka gaslight)"
+          label="Prompt Template (formerly gaslight)"
           helperText={
             <>
               <div>


### PR DESCRIPTION
- [fix: properly load suggestion for prompt template conversion](https://github.com/agnaistic/agnai/commit/d0240782bcf38a39f13071b8bdefd0f747f78665)
- [fix: in gaslight update modal, add helper text saying the System Prompt only support {{user}} and {{char}}](https://github.com/agnaistic/agnai/commit/987d784eb42c731249808ad53e1529efd823ad9f) 
- [fix: remove {{chat_age}} and {{idle_duration}} from system prompt. lets keep it consistent with character system prompt, user can still include those in prompt template and ujb.](https://github.com/agnaistic/agnai/commit/7e125ac15a2faf654c8f50aa348cd7fa0a706c16) 
- [ui: reword aka gaslight to formerly gaslight](https://github.com/agnaistic/agnai/commit/8274bc9f93159a91576d038d7b21f160e73054a5)
- [fix: make {{system_prompt}} not support other placeholders than {{char}} and {{user}}](https://github.com/agnaistic/agnai/commit/e8f6a9d2efcc2e37b9de60aab921b8dae3ccf462)
- [feat: support {{original}}](https://github.com/agnaistic/agnai/commit/a513f06e44929351d9223afc1b43d342fad081f7)
- [ui: improve name and helper text for Description which now doubles as Creators Notes](https://github.com/agnaistic/agnai/commit/cf88a297a99368ef6c8e4a88639ba40707605330) 

v2 still flagged, but should be ready to unflag