### PR TITLE
Implement KoboldCPP Tokenstreaming 

### DIFF
--- a/srv/adapter/kobold.ts
+++ b/srv/adapter/kobold.ts
@@ -1,9 +1,11 @@
 import needle from 'needle'
 import { defaultPresets } from '../../common/presets'
 import { logger } from '../logger'
-import { normalizeUrl, trimResponseV2 } from '../api/chat/common'
+import { normalizeUrl, sanitise, sanitiseAndTrim, trimResponseV2 } from '../api/chat/common'
 import { ModelAdapter } from './type'
+import { needleToSSE } from './stream'
 
+const MIN_STREAMING_KCPPVERSION = "1.30";
 const REQUIRED_SAMPLERS = defaultPresets.basic.order
 
 const base = {
@@ -24,6 +26,8 @@ export const handleKobold: ModelAdapter = async function* ({
   ...opts
 }) {
   const body = { ...base, ...settings, prompt }
+
+  const baseURL = `${normalizeUrl(user.koboldUrl)}`;
 
   // Kobold has a stop requence parameter which automatically
   // halts generation when a certain token is generated
@@ -55,7 +59,65 @@ export const handleKobold: ModelAdapter = async function* ({
 
   log.debug(body, 'Kobold payload')
 
-  const resp = await needle('post', `${normalizeUrl(user.koboldUrl)}/api/v1/generate`, body, {
+  // Only KoboldCPP at version 1.30 and higher has streaming support
+  const isStreamSupported = checkStreamSupported(`${baseURL}/api/extra/version`)
+
+  const stream = (opts.gen.streamResponse && isStreamSupported) ?
+    streamCompletition(`${baseURL}/api/extra/generate/stream`, body) : 
+    fullCompletion(`${baseURL}/api/extra/generate/stream`, body)
+
+
+  let accum = ''
+
+  while (true) {
+    const generated = await stream.next()
+
+    if (!generated || !generated.value) break
+
+    if ('error' in generated.value) {
+      yield { error: generated.value.error }
+      return
+    }
+
+    if ('token' in generated.value) {
+        accum += generated.value.token
+        yield { partial: sanitiseAndTrim(accum, prompt, opts.replyAs, characters, members) }
+    }
+
+    if ('tokens' in generated.value) {
+      accum = generated.value.tokens
+      break
+    }
+  }
+
+  const parsed = sanitise(accum)
+  const trimmed = trimResponseV2(parsed, opts.replyAs, members, characters, [
+    'END_OF_DIALOG',
+    'You:',
+  ])
+
+  yield trimmed || parsed
+}
+
+const checkStreamSupported = async function* (versioncheckURL: any) {
+  const result = await needle("get", versioncheckURL);
+
+  if (result.statusCode != 200) return false;
+
+  const { body } = result;
+
+  if (body.result != "KoboldCpp") return false;
+
+
+  if ((body.version ?? "0.0").localeCompare(MIN_STREAMING_KCPPVERSION, undefined, {
+    numeric: true, sensitivity: 'base'
+  }) > -1) return false;
+
+  return true;
+}
+
+const fullCompletion = async function* (genURL: string, body: any) {
+  const resp = await needle('post', `${genURL}/api/v1/generate`, body, {
     headers: { 'Bypass-Tunnel-Reminder': 'true' },
     json: true,
   }).catch((err) => ({ error: err }))
@@ -72,15 +134,54 @@ export const handleKobold: ModelAdapter = async function* ({
   }
 
   const text = resp.body.results?.[0]?.text as string
+
   if (text) {
-    const trimmed = trimResponseV2(text, opts.replyAs, members, characters, [
-      'END_OF_DIALOG',
-      'You:',
-    ])
-    yield trimmed || text
+    return { tokens: text };
   } else {
     logger.error({ err: resp.body }, 'Failed to generate text using Kobold adapter')
     yield { error: `Kobold failed to generate a response: ${resp.body}` }
+    return;
+  }
+}
+
+const streamCompletition = async function* (streamUrl: any, body: any) {
+  const resp = needle.post(streamUrl, body, {
+    parse: false,
+    json: true,
+    headers: {
+      Accept: `text/event-stream`,
+    },
+  })
+
+  const tokens = []
+
+  try {
+    const events = needleToSSE(resp)
+
+    for await (const event of events) {
+      const lines = event.split('\n')
+
+      for (const line of lines) {
+        if (!line.startsWith('data:')) continue
+        const data = JSON.parse(line.slice(5)) as {
+          token: string
+          final: boolean
+          ptr: number
+          error?: string
+        }
+        if (data.error) {
+          yield { error: `Kobold streaming request failed: ${data.error}` }
+          return
+        }
+
+        tokens.push(data.token)
+        yield { token: data.token }
+      }
+    }
+  } catch (err: any) {
+    yield { error: `Kobold streaming request failed: ${err.message || err}` }
     return
   }
+
+  return { text: tokens.join('') }
 }

--- a/srv/adapter/kobold.ts
+++ b/srv/adapter/kobold.ts
@@ -60,7 +60,7 @@ export const handleKobold: ModelAdapter = async function* ({
   log.debug(body, 'Kobold payload')
 
   // Only KoboldCPP at version 1.30 and higher has streaming support
-  const isStreamSupported = checkStreamSupported(`${baseURL}/api/extra/version`)
+  const isStreamSupported = await checkStreamSupported(`${baseURL}/api/extra/version`)
 
   const stream =
     opts.gen.streamResponse && isStreamSupported
@@ -99,7 +99,7 @@ export const handleKobold: ModelAdapter = async function* ({
   yield trimmed || parsed
 }
 
-const checkStreamSupported = async function* (versioncheckURL: any) {
+const checkStreamSupported = async function (versioncheckURL: any) {
   const result = await needle('get', versioncheckURL)
 
   if (result.statusCode != 200 || result.errored) return false
@@ -108,13 +108,13 @@ const checkStreamSupported = async function* (versioncheckURL: any) {
 
   if (body.result != 'KoboldCpp') return false
 
-  if (
+  const isSupportedVersion =
     (body.version ?? '0.0').localeCompare(MIN_STREAMING_KCPPVERSION, undefined, {
       numeric: true,
       sensitivity: 'base',
     }) > -1
-  )
-    return false
+
+  if (!isSupportedVersion) return false
 
   return true
 }

--- a/srv/adapter/kobold.ts
+++ b/srv/adapter/kobold.ts
@@ -64,7 +64,7 @@ export const handleKobold: ModelAdapter = async function* ({
 
   const stream = (opts.gen.streamResponse && isStreamSupported) ?
     streamCompletition(`${baseURL}/api/extra/generate/stream`, body) : 
-    fullCompletion(`${baseURL}/api/extra/generate/stream`, body)
+    fullCompletion(`${baseURL}/api/v1/generate`, body)
 
 
   let accum = ''
@@ -102,7 +102,7 @@ export const handleKobold: ModelAdapter = async function* ({
 const checkStreamSupported = async function* (versioncheckURL: any) {
   const result = await needle("get", versioncheckURL);
 
-  if (result.statusCode != 200) return false;
+  if (result.statusCode != 200 || result.errored) return false;
 
   const { body } = result;
 
@@ -117,7 +117,7 @@ const checkStreamSupported = async function* (versioncheckURL: any) {
 }
 
 const fullCompletion = async function* (genURL: string, body: any) {
-  const resp = await needle('post', `${genURL}/api/v1/generate`, body, {
+  const resp = await needle('post', genURL, body, {
     headers: { 'Bypass-Tunnel-Reminder': 'true' },
     json: true,
   }).catch((err) => ({ error: err }))

--- a/srv/adapter/kobold.ts
+++ b/srv/adapter/kobold.ts
@@ -99,17 +99,21 @@ export const handleKobold: ModelAdapter = async function* ({
   yield trimmed || parsed
 }
 
-const checkStreamSupported = async function (versioncheckURL: any) {
-  const result = await needle('get', versioncheckURL)
+async function checkStreamSupported(versioncheckURL: any) {
+  const result = await needle('get', versioncheckURL).catch((err) => ({ err }))
+  if ('err' in result) {
+    return false
+  }
 
-  if (result.statusCode != 200 || result.errored) return false
+  if (result.statusCode !== 200 || result.errored) return false
 
   const { body } = result
 
-  if (body.result != 'KoboldCpp') return false
+  if (body.result !== 'KoboldCpp') return false
+  const version: string = body.version ?? '0.0'
 
   const isSupportedVersion =
-    (body.version ?? '0.0').localeCompare(MIN_STREAMING_KCPPVERSION, undefined, {
+    version.localeCompare(MIN_STREAMING_KCPPVERSION, undefined, {
       numeric: true,
       sensitivity: 'base',
     }) > -1

--- a/srv/adapter/kobold.ts
+++ b/srv/adapter/kobold.ts
@@ -5,7 +5,7 @@ import { normalizeUrl, sanitise, sanitiseAndTrim, trimResponseV2 } from '../api/
 import { ModelAdapter } from './type'
 import { needleToSSE } from './stream'
 
-const MIN_STREAMING_KCPPVERSION = "1.30";
+const MIN_STREAMING_KCPPVERSION = '1.30'
 const REQUIRED_SAMPLERS = defaultPresets.basic.order
 
 const base = {
@@ -27,7 +27,7 @@ export const handleKobold: ModelAdapter = async function* ({
 }) {
   const body = { ...base, ...settings, prompt }
 
-  const baseURL = `${normalizeUrl(user.koboldUrl)}`;
+  const baseURL = `${normalizeUrl(user.koboldUrl)}`
 
   // Kobold has a stop requence parameter which automatically
   // halts generation when a certain token is generated
@@ -62,10 +62,10 @@ export const handleKobold: ModelAdapter = async function* ({
   // Only KoboldCPP at version 1.30 and higher has streaming support
   const isStreamSupported = checkStreamSupported(`${baseURL}/api/extra/version`)
 
-  const stream = (opts.gen.streamResponse && isStreamSupported) ?
-    streamCompletition(`${baseURL}/api/extra/generate/stream`, body) : 
-    fullCompletion(`${baseURL}/api/v1/generate`, body)
-
+  const stream =
+    opts.gen.streamResponse && isStreamSupported
+      ? streamCompletition(`${baseURL}/api/extra/generate/stream`, body)
+      : fullCompletion(`${baseURL}/api/v1/generate`, body)
 
   let accum = ''
 
@@ -80,8 +80,8 @@ export const handleKobold: ModelAdapter = async function* ({
     }
 
     if ('token' in generated.value) {
-        accum += generated.value.token
-        yield { partial: sanitiseAndTrim(accum, prompt, opts.replyAs, characters, members) }
+      accum += generated.value.token
+      yield { partial: sanitiseAndTrim(accum, prompt, opts.replyAs, characters, members) }
     }
 
     if ('tokens' in generated.value) {
@@ -100,20 +100,23 @@ export const handleKobold: ModelAdapter = async function* ({
 }
 
 const checkStreamSupported = async function* (versioncheckURL: any) {
-  const result = await needle("get", versioncheckURL);
+  const result = await needle('get', versioncheckURL)
 
-  if (result.statusCode != 200 || result.errored) return false;
+  if (result.statusCode != 200 || result.errored) return false
 
-  const { body } = result;
+  const { body } = result
 
-  if (body.result != "KoboldCpp") return false;
+  if (body.result != 'KoboldCpp') return false
 
+  if (
+    (body.version ?? '0.0').localeCompare(MIN_STREAMING_KCPPVERSION, undefined, {
+      numeric: true,
+      sensitivity: 'base',
+    }) > -1
+  )
+    return false
 
-  if ((body.version ?? "0.0").localeCompare(MIN_STREAMING_KCPPVERSION, undefined, {
-    numeric: true, sensitivity: 'base'
-  }) > -1) return false;
-
-  return true;
+  return true
 }
 
 const fullCompletion = async function* (genURL: string, body: any) {
@@ -136,11 +139,11 @@ const fullCompletion = async function* (genURL: string, body: any) {
   const text = resp.body.results?.[0]?.text as string
 
   if (text) {
-    return { tokens: text };
+    return { tokens: text }
   } else {
     logger.error({ err: resp.body }, 'Failed to generate text using Kobold adapter')
     yield { error: `Kobold failed to generate a response: ${resp.body}` }
-    return;
+    return
   }
 }
 


### PR DESCRIPTION
## What to expect

This PR implements Tokenstreaming for Kobold backends. 
As of right now, only KoboldCpp 1.30 and up have this feature, so this PR will also check if the version is currently supported.

