### PR TITLE
Add support for Anthropic API streaming

### DIFF
--- a/common/adapters.ts
+++ b/common/adapters.ts
@@ -239,7 +239,7 @@ export const adapterSettings: {
   oaiModel: ['openai', 'kobold'],
   frequencyPenalty: ['openai', 'kobold', 'novel'],
   presencePenalty: ['openai', 'kobold', 'novel'],
-  streamResponse: ['openai', 'kobold', 'novel'],
+  streamResponse: ['openai', 'kobold', 'novel', 'claude'],
 
   addBosToken: ['ooba'],
   banEosToken: ['ooba'],

--- a/srv/adapter/claude.ts
+++ b/srv/adapter/claude.ts
@@ -97,14 +97,12 @@ export const handleClaude: ModelAdapter = async function* (opts) {
     }
 
     if ('error' in generated.value) {
-      log.error({ err: generated.value.error }, 'yielded error')
       yield generated.value
       return
     }
 
     if ('token' in generated.value) {
       acc += generated.value.token
-      log.debug({ token: generated.value.token }, 'yielded token')
       yield {
         partial: sanitiseAndTrim(acc, requestBody.prompt, opts.replyAs, opts.characters, members),
       }

--- a/srv/adapter/claude.ts
+++ b/srv/adapter/claude.ts
@@ -1,5 +1,6 @@
 import needle from 'needle'
-import { sanitise, trimResponseV2 } from '../api/chat/common'
+import { sanitiseAndTrim } from '../api/chat/common'
+import { needleToSSE } from './stream'
 import { ModelAdapter, AdapterProps } from './type'
 import { decryptText } from '../db/util'
 import { defaultPresets } from '../../common/presets'
@@ -13,9 +14,29 @@ import {
   SAMPLE_CHAT_MARKER,
 } from '../../common/prompt'
 import { AppSchema } from '../../common/types/schema'
+import { AppLog } from '../logger'
 import { getEncoder } from '../tokenize'
+import { publishOne } from '../api/ws/handle'
 
 const baseUrl = `https://api.anthropic.com/v1/complete`
+const apiVersion = '2023-06-01' // https://docs.anthropic.com/claude/reference/versioning
+
+type ClaudeCompletion = {
+  completion: string
+  stop_reason: string | null
+  model: string
+  /** If `stop_reason` is "stop_sequence", this is the particular stop sequence that was matched. */
+  stop: string | null
+  log_id: string
+}
+
+type CompletionGenerator = (
+  url: string,
+  body: Record<string, any>,
+  headers: Record<string, string | string[] | number>,
+  userId: string,
+  log: AppLog
+) => AsyncGenerator<{ error: string } | { token: string }, ClaudeCompletion | undefined>
 
 // There's no tokenizer for Claude, we use OpenAI's as an estimation
 const encoder = getEncoder('openai', OPENAI_MODELS.Turbo)
@@ -43,6 +64,7 @@ export const handleClaude: ModelAdapter = async function* (opts) {
 
   const headers: any = {
     'Content-Type': 'application/json',
+    'anthropic-version': apiVersion,
   }
 
   const useThirdPartyPassword = base.changed && isThirdParty && user.thirdPartyPassword
@@ -59,7 +81,66 @@ export const handleClaude: ModelAdapter = async function* (opts) {
 
   log.debug(requestBody, 'Claude payload')
 
-  const resp = await needle('post', base.url, JSON.stringify(requestBody), {
+  const streamResponse =
+    (gen.streamResponse && opts.kind !== 'summary') ?? defaultPresets.claude.streamResponse
+  const iterator = streamResponse
+    ? streamCompletion(base.url, requestBody, headers, opts.user._id, log)
+    : requestFullCompletion(base.url, requestBody, headers, opts.user._id, log)
+  let acc = ''
+  let resp: ClaudeCompletion | undefined
+
+  while (true) {
+    let generated = await iterator.next()
+
+    if (generated.done) {
+      resp = generated.value
+      break
+    }
+
+    if ('error' in generated.value) {
+      yield generated.value
+      return
+    }
+
+    if ('token' in generated.value) {
+      acc += generated.value.token
+      yield {
+        partial: sanitiseAndTrim(acc, requestBody.prompt, opts.replyAs, opts.characters, members),
+      }
+    }
+  }
+
+  try {
+    const completion = resp?.completion || ''
+    if (!completion) {
+      log.error({ body: resp }, 'Claude request failed: Empty response')
+      yield { error: `Claude request failed: Received empty response. Try again.` }
+    } else {
+      yield sanitiseAndTrim(completion, requestBody.prompt, opts.replyAs, opts.characters, members)
+    }
+  } catch (ex: any) {
+    log.error({ err: ex }, 'Claude failed to parse')
+    yield { error: `Claude request failed: ${ex.message}` }
+    return
+  }
+}
+
+function getBaseUrl(user: AppSchema.User, isThirdParty?: boolean) {
+  if (isThirdParty && user.thirdPartyFormat === 'claude' && user.koboldUrl) {
+    return { url: user.koboldUrl, changed: true }
+  }
+
+  return { url: baseUrl, changed: false }
+}
+
+const requestFullCompletion: CompletionGenerator = async function* (
+  url,
+  body,
+  headers,
+  userId,
+  log
+) {
+  const resp = await needle('post', url, JSON.stringify(body), {
     json: true,
     headers,
   }).catch((err) => ({ error: err }))
@@ -76,33 +157,73 @@ export const handleClaude: ModelAdapter = async function* (opts) {
     return
   }
 
-  try {
-    const completion = resp.body.completion
-    if (!completion) {
-      log.error({ body: resp.body }, 'OpenAI request failed: Empty response')
-      yield { error: `OpenAI request failed: Received empty response. Try again.` }
-      return
-    } else {
-      const sanitised = sanitise(completion)
-      const trimmed = trimResponseV2(sanitised, opts.replyAs, members, opts.characters, [
-        'END_OF_DIALOG',
-      ])
-      yield trimmed || sanitised
-      return
-    }
-  } catch (ex: any) {
-    log.error({ err: ex }, 'Claude failed to parse')
-    yield { error: `Claude request failed: ${ex.message}` }
-    return
-  }
+  return resp.body
 }
 
-function getBaseUrl(user: AppSchema.User, isThirdParty?: boolean) {
-  if (isThirdParty && user.thirdPartyFormat === 'claude' && user.koboldUrl) {
-    return { url: user.koboldUrl, changed: true }
+const streamCompletion: CompletionGenerator = async function* (url, body, headers, userId, log) {
+  const resp = needle.post(url, JSON.stringify(body), {
+    parse: false,
+    headers: {
+      ...headers,
+      Accept: 'text/event-stream',
+    },
+  })
+
+  const tokens = []
+  let meta: Omit<ClaudeCompletion, 'completion'> = {
+    stop_reason: null,
+    model: '',
+    stop: null,
+    log_id: '',
   }
 
-  return { url: baseUrl, changed: false }
+  try {
+    const events = needleToSSE(resp)
+
+    // https://docs.anthropic.com/claude/reference/streaming
+    for await (const event of events) {
+      if (!event.startsWith('event:')) {
+        continue
+      }
+
+      const eventType = event.slice('event:'.length).trim()
+      const eventData = event.split('\n').pop()?.slice('data:'.length).trim() ?? '{}'
+      switch (eventType) {
+        case 'completion':
+          const delta: Partial<ClaudeCompletion> = JSON.parse(eventData)
+          const token = delta.completion || ''
+          meta = { ...meta, ...delta }
+          tokens.push(token)
+          yield { token }
+          break
+        case 'error':
+          const parsedError = JSON.parse(eventData)
+          log.warn({ error: parsedError }, '[Claude] Received SSE error event')
+          const message = parsedError?.error?.message
+            ? `Anthropic interrupted the response: ${parsedError.error.message}`
+            : `Anthropic interrupted the response.`
+
+          if (!tokens.length) {
+            yield { error: message }
+            return
+          }
+
+          publishOne(userId, { type: 'notification', level: 'warn', message })
+          break
+        case 'ping':
+          break
+        default:
+          log.warn({ event }, '[Claude] Received unrecognized SSE event')
+          break
+      }
+    }
+  } catch (err: any) {
+    log.error({ err }, '[Claude] SSE stream failed')
+    yield { error: `Claude streaming request failed: ${err.message}` }
+    return
+  }
+
+  return { completion: tokens.join(''), ...meta }
 }
 
 function createClaudePrompt(opts: AdapterProps): string {

--- a/srv/adapter/kobold.ts
+++ b/srv/adapter/kobold.ts
@@ -167,24 +167,20 @@ const streamCompletition = async function* (streamUrl: any, body: any) {
     const events = needleToSSE(resp)
 
     for await (const event of events) {
-      const lines = event.split('\n')
-
-      for (const line of lines) {
-        if (!line.startsWith('data:')) continue
-        const data = JSON.parse(line.slice(5)) as {
-          token: string
-          final: boolean
-          ptr: number
-          error?: string
-        }
-        if (data.error) {
-          yield { error: `Kobold streaming request failed: ${data.error}` }
-          return
-        }
-
-        tokens.push(data.token)
-        yield { token: data.token }
+      if (!event.data) continue
+      const data = JSON.parse(event.data) as {
+        token: string
+        final: boolean
+        ptr: number
+        error?: string
       }
+      if (data.error) {
+        yield { error: `Kobold streaming request failed: ${data.error}` }
+        return
+      }
+
+      tokens.push(data.token)
+      yield { token: data.token }
     }
   } catch (err: any) {
     yield { error: `Kobold streaming request failed: ${err.message || err}` }

--- a/srv/adapter/novel.ts
+++ b/srv/adapter/novel.ts
@@ -149,7 +149,7 @@ const streamCompletition = async function* (headers: any, body: any, _log: AppLo
   try {
     const events = needleToSSE(resp)
     for await (const event of events) {
-      if (event.type !== "newToken") continue
+      if (event.type !== 'newToken') continue
       const data = JSON.parse(event.data) as {
         token: string
         final: boolean

--- a/srv/adapter/openai.ts
+++ b/srv/adapter/openai.ts
@@ -239,16 +239,15 @@ const streamCompletion: CompletionGenerator = async function* (userId, url, head
   try {
     const events = needleToSSE(resp)
     for await (const event of events) {
-      // According to OpenAI's docs their SSE stream only uses `data` events.
-      if (!event.startsWith('data: ')) {
+      if (!event.data) {
         continue
       }
 
-      if (event === 'data: [DONE]') {
+      if (event.data === '[DONE]') {
         break
       }
 
-      const parsed: Completion<AsyncDelta> = JSON.parse(event.slice('data: '.length))
+      const parsed: Completion<AsyncDelta> = JSON.parse(event.data)
       const { choices, ...evt } = parsed
       if (!choices || !choices[0]) {
         log.warn({ sse: event }, `[OpenAI] Received invalid SSE during stream`)

--- a/srv/adapter/openrouter.ts
+++ b/srv/adapter/openrouter.ts
@@ -136,9 +136,14 @@ function getResponseText(resp: any, log: AppLog) {
     return new Error(`Response contained no data (No choices)`)
   }
 
-  const message = resp.choices[0].message
+  const choice = resp.choices[0]
+  if (choice.text) return choice.text as string
+
+  const message = choice.message
+  if (typeof message === 'string') return message
+
   if (!message || !message.content) {
-    log.warn({ resp }, 'OpenRouter response was empty (No text')
+    log.warn({ resp }, 'OpenRouter response was empty (No text)')
     return new Error(`Response contained no data (No text)`)
   }
 

--- a/srv/adapter/openrouter.ts
+++ b/srv/adapter/openrouter.ts
@@ -4,6 +4,7 @@ import { toChatCompletionPayload } from './chat-completion'
 import { registerAdapter } from './register'
 import { ModelAdapter } from './type'
 import { sanitiseAndTrim } from '../api/chat/common'
+import { AppLog } from '../logger'
 
 const baseUrl = 'https://openrouter.ai/api/v1'
 const chatUrl = `${baseUrl}/chat/completions`
@@ -64,15 +65,15 @@ export const handleOpenRouter: ModelAdapter = async function* (opts) {
     }
   }
 
-  const text = getResponseText(response)
+  const text = getResponseText(response, opts.log)
   if (text instanceof Error) {
-    yield { error: `OpenAI returned an error: ${text.message}` }
+    yield { error: `OpenRouter response failed: ${text.message}` }
     return
   }
 
   if (!text?.length) {
     opts.log.error({ body: response }, 'OpenRouter request failed: Empty response')
-    yield { error: `OpenAI request failed: Received empty response. Try again.` }
+    yield { error: `OpenRouter request failed: Received empty response. Try again.` }
     return
   }
 
@@ -125,18 +126,20 @@ registerAdapter('openrouter', handleOpenRouter, {
   options: ['temp', 'maxTokens'],
 })
 
-function getResponseText(resp: any) {
+function getResponseText(resp: any, log: AppLog) {
   if (typeof resp === 'string') {
     resp = JSON.parse(resp)
   }
 
   if (!resp.choices || !Array.isArray(resp.choices) || resp.choices.length === 0) {
-    return new Error(`OpenRouter request failed: Response contained not data`)
+    log.warn({ resp }, 'OpenRouter response was empty (No choices)')
+    return new Error(`Response contained no data (No choices)`)
   }
 
   const message = resp.choices[0].message
   if (!message || !message.content) {
-    return new Error(`Response contained not data`)
+    log.warn({ resp }, 'OpenRouter response was empty (No text')
+    return new Error(`Response contained no data (No text)`)
   }
 
   return message.content as string

--- a/srv/adapter/stream.ts
+++ b/srv/adapter/stream.ts
@@ -62,23 +62,30 @@ export type ServerSentEvent = { id?: string; type?: string; data: string }
 
 function parseEvent(msg: string) {
   const buffer: ServerSentEvent = { data: '' }
-  return msg.split(/\r?\n/).reduce((event, line) => {
-    const sep = line.indexOf(':')
-    const field = sep === -1 ? line : line.slice(0, sep)
-    const value = sep === -1 ? '' : line.slice(sep + 1)
-    switch (field) {
-      case 'id':
-        event.id = value.trim()
-        break
-      case 'event':
-        event.type = value.trim()
-        break
-      case 'data':
-        event.data += value.trimStart()
-        break
-      default:
-        break
-    }
-    return event
-  }, buffer)
+  return msg.split(/\r?\n/).reduce(parseLine, buffer)
+}
+
+function parseLine(event: ServerSentEvent, line: string) {
+  const sep = line.indexOf(':')
+  const field = sep === -1 ? line : line.slice(0, sep)
+  const value = sep === -1 ? '' : line.slice(sep + 1)
+
+  switch (field) {
+    case 'id':
+      event.id = value.trim()
+      break
+
+    case 'event':
+      event.type = value.trim()
+      break
+
+    case 'data':
+      event.data += value.trimStart()
+      break
+
+    default:
+      break
+  }
+
+  return event
 }


### PR DESCRIPTION
Adds support for Anthropic's [recently reworked SSE streaming API](https://docs.anthropic.com/claude/reference/streaming) to enable Claude token streaming.  Because Anthropic now has multiple versions of their API, we now send the `anthropic-version: 2023-06-01` header to opt into the new version.  My implementation is not compatible with the old streaming format, which is currently the default Anthropic uses if you do not request a particular version, but which will (presumably) eventually be deprecated/removed.

This also makes some adjustments to the `needleToSSE` generator to teach it how to parse most types of SSE messages, implemented against the spec at https://html.spec.whatwg.org/multipage/server-sent-events.html.  This allows the individual adapters to not have to worry about figuring out event types, field names, buffering `data` across multiple lines, etc.

Resolves #455.
## Tests
- Claude non-streaming (existing)
- Claude streaming works (new)
- OpenAI streaming (existing)

https://github.com/agnaistic/agnai/assets/92774204/093d7a05-174a-43c7-aa4f-88ef4feca8f1

- NovelAI (existing) (Clio is trying her best)

https://github.com/agnaistic/agnai/assets/92774204/751450d6-156c-4c7b-9bfa-8717c043045b
