### PR TITLE
Fix impersonation not persisting after page reload

### DIFF
--- a/web/store/character.ts
+++ b/web/store/character.ts
@@ -71,7 +71,7 @@ export const characterStore = createStore<CharacterState>(
     characterStore.setState(initState)
   })
 
-  events.on(EVENTS.init, (init) => {
+  events.on(EVENTS.init, async (init) => {
     if (!init.characters) {
       characterStore.getCharacters()
       return
@@ -81,7 +81,7 @@ export const characterStore = createStore<CharacterState>(
       characters: { list: init.characters, map: toCharacterMap(init.characters), loaded: true },
     })
 
-    const impersonateId = storage.localGetItem(IMPERSONATE_KEY)
+    const impersonateId = await storage.getItem(IMPERSONATE_KEY)
     if (!impersonateId) return
 
     const impersonating = init.characters?.find(
@@ -119,8 +119,9 @@ export const characterStore = createStore<CharacterState>(
       }
 
       if (res.result && !state.impersonating) {
-        const id = storage.localGetItem(IMPERSONATE_KEY)
+        const id = await storage.getItem(IMPERSONATE_KEY)
         const impersonating = res.result.characters.find((ch: AppSchema.Character) => ch._id === id)
+        console.log('getCharacters -- impersonating', impersonating)
 
         return {
           characters: {


### PR DESCRIPTION
I noticed that the impersonate feature on my local Agnai had become stuck with a character I impersonate a couple weeks ago.  Trying to clear or change the impersonated character would only work until the page reloaded.

Looks like this is because at some point, `localforage` was brought in to use IndexedDB for persistence for some features, including the impersonated character ID.  At that point, impersonation was adjusted to _write_ to `localforage`, but it still _reads_ from `localStorage`. so persistence appears broken.

This PR just adjusts impersonation to both write to and read from `localforage`.