### PR TITLE
Post sample chat parsing

### DIFF
--- a/srv/adapter/chat-completion.ts
+++ b/srv/adapter/chat-completion.ts
@@ -121,7 +121,7 @@ export function toChatCompletionPayload(opts: AdapterProps, maxTokens: number): 
 
 export function splitSampleChat(opts: SplitSampleChatProps) {
   const { sampleChat, char, sender, budget } = opts
-  const regex = new RegExp(`(?<=\\n)(?=${escapeRegex(char)}:|${escapeRegex(sender)}:|<start>)`, 'gi')
+  const regex = new RegExp(`(?<=\\n)(?=${escapeRegex(char)}:|${escapeRegex(sender)}:|System:|<start>)`, 'gi')
   const additions: CompletionItem[] = []
   let tokens = 0
 
@@ -142,7 +142,7 @@ export function splitSampleChat(opts: SplitSampleChatProps) {
       continue
     }
 
-    const sample = trimmed
+    const sample = trimmed.toLowerCase().startsWith('system:') ? trimmed.slice(7).trim() : trimmed
     const role = sample.startsWith(char + ':') ? 'assistant' : sample.startsWith(sender + ':') ? 'user' : 'system'
 
     const msg: CompletionItem = {

--- a/tests/__snapshots__/chat-model-sample-chat.spec.js.snap
+++ b/tests/__snapshots__/chat-model-sample-chat.spec.js.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Chat Completion Example Dialogue:: should correctly separate out system messages it is explicitly handed, such as a post-sample marker string 1`] = `
+"[
+  {
+    \\"role\\": \\"user\\",
+    \\"content\\": \\"Sam: hey\\"
+  },
+  {
+    \\"role\\": \\"assistant\\",
+    \\"content\\": \\"Vader: hi!\\"
+  },
+  {
+    \\"role\\": \\"system\\",
+    \\"content\\": \\"New conversation started. Previous conversations are examples only.\\"
+  },
+  {
+    \\"role\\": \\"assistant\\",
+    \\"content\\": \\"Vader: bye Sam\\"
+  },
+  {
+    \\"role\\": \\"user\\",
+    \\"content\\": \\"Sam: byebye Vader\\"
+  },
+  {
+    \\"role\\": \\"system\\",
+    \\"content\\": \\"New conversation started. Previous conversations are examples only.\\"
+  }
+]"
+`;
+
 exports[`Chat Completion Example Dialogue:: should properly convert <START> (case insensitive) and split basic messages 1`] = `
 "[
   {

--- a/tests/chat-model-sample-chat.spec.ts
+++ b/tests/chat-model-sample-chat.spec.ts
@@ -71,6 +71,17 @@ describe('Chat Completion Example Dialogue::', () => {
       Sam: More interesting!`
     expect(testInput(input, 25)).to.matchSnapshot()
   })
+
+  it('should correctly separate out system messages it is explicitly handed, such as a post-sample marker string', () => {
+    const input = neat`Sam: hey
+      Vader: hi!
+      <START>
+      Vader: bye Sam
+      Sam: byebye Vader
+      System: New conversation started. Previous conversations are examples only.`
+    const output = testInput(input)
+    expect(output).toMatchSnapshot()
+  })
 })
 
 function testInput(input: string, budget?: number) {


### PR DESCRIPTION
Currently for OAI models, the automatic post-sample system message ends up sent as part of an assistant or user message e.g.
```
<START>
Person: Hello, robot.
Robot: Beep hello human.
```
goes to the model as
```
  {
    "role": "system",
    "content": "New conversation started. Previous conversations are examples only."
  },
  {
    "role": "user",
    "content": "Person: Hello, robot."
  },
  {
    "role": "assistant",
    "content": "Robot: Beep hello human.\nSystem: New conversation started. Previous conversations are examples only."
  }
```
this PR parses `\nSystem:` so that the final system message is separated out the same way as the `<START>` ones:
```
  {
    "role": "system",
    "content": "New conversation started. Previous conversations are examples only."
  },
  {
    "role": "user",
    "content": "Person: Hello, robot."
  },
  {
    "role": "assistant",
    "content": "Robot: Beep hello human."
  },
  {
    "role": "system",
    "content": "New conversation started. Previous conversations are examples only."
  }
```