### PR TITLE
NovelAI generation improvements

### DIFF
--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -760,7 +760,7 @@ export function getContextLimit(
       return configuredMax - genAmount
 
     case 'novel': {
-      if (model === NOVEL_MODELS.clio_v1) return 8000 - genAmount
+      if (model === NOVEL_MODELS.clio_v1 || model == NOVEL_MODELS.kayra_v1) return 8000 - genAmount
       return configuredMax - genAmount
     }
 

--- a/common/tokenize.ts
+++ b/common/tokenize.ts
@@ -1,4 +1,4 @@
-export type Encoder = (text: string) => number
+export type Encoder<B extends boolean = false> = (text: string, returnTokens?: B) => (B extends true ? number[] : number)
 
 export type Tokenizer = {
   decode: (tokens: Int32Array) => string

--- a/srv/tokenize.ts
+++ b/srv/tokenize.ts
@@ -28,13 +28,13 @@ const main: Encoder = function main(value: string) {
   return gpt.encode(value).length
 }
 
-const novel: Encoder = function krake(value: string) {
+const novelNSV1: Encoder = function krake(value: string) {
   const cleaned = sp.cleanText(value)
   const tokens = nerdstash.encodeIds(cleaned)
   return tokens.length
 }
 
-const novelClio: Encoder = function clio(value: string) {
+const novelNSV2: Encoder = function clio(value: string) {
   const cleaned = sp.cleanText(value)
   const tokens = nerdstashV2.encodeIds(cleaned)
   return tokens.length + 4
@@ -68,16 +68,17 @@ export function getEncoder(adapter: AIAdapter | 'main', model?: string) {
   if (adapter !== 'openai' && adapter !== 'novel') return main
 
   if (adapter === 'novel') {
-    if (model === NOVEL_MODELS.clio_v1) return novelClio
-    return novel
+    if (model === NOVEL_MODELS.kayra_v1) return novelNSV2
+    if (model === NOVEL_MODELS.clio_v1) return novelNSV1
+    return main
   }
 
   if (model === OPENAI_MODELS.DaVinci) {
-    return davinci ?? novel
+    return davinci ?? main
   }
 
   if (model && TURBO_MODELS.has(model)) {
-    return turbo ?? novel
+    return turbo ?? main
   }
 
   return main


### PR DESCRIPTION
This PR addresses multiple issues with NovelAI generations API support:
- The new models were using the wrong tokenizer (where the Clio model was using NerdStashV2 tokenizer whilst being a V1 model, and Kayra was using NerdStashV1 whilst being V2.
- The stop sequences are now properly implemented and will not interrupt the generation upon an emit colon. This required adding support for returning tokens for a text, which has been done in a non-invasive way (the old API remains the same).