### PR TITLE
fix: <q> technique was breaking some rendered markdown due to wrapping double quotes inside generated html tags with <p> tags

### DIFF
--- a/web/pages/Chat/components/Message.css
+++ b/web/pages/Chat/components/Message.css
@@ -13,6 +13,10 @@ em {
   color: var(--text-quote-color);
 }
 
+.rendered-markdown img {
+  display: inline-block; /* markdown images are expected to be inline-block */
+}
+
 .rendered-markdown q::before,
 .rendered-markdown q::after {
   content: '';

--- a/web/pages/Chat/components/Message.tsx
+++ b/web/pages/Chat/components/Message.tsx
@@ -651,9 +651,10 @@ function renderMessage(ctx: ContextState, text: string, isUser: boolean, adapter
 
 function wrapWithQuoteElement(str: string) {
   return str.replace(
-    // we first match code blocks to ensure we do NOTHING to what's inside them
+    // we first match code blocks AND html tags
+    // to ensure we do NOTHING to what's inside them
     // then we match "regular quotes" and“'pretty quotes” as capture group
-    /```[\s\S]*?```|``[\s\S]*?``|`[\s\S]*?`|(\".+?\")|(\u201C.+?\u201D)/gm,
+    /<[\s\S]*?>|```[\s\S]*?```|``[\s\S]*?``|`[\s\S]*?`|(\".+?\")|(\u201C.+?\u201D)/gm,
     wrapCaptureGroups
   )
 }


### PR DESCRIPTION
The <q> thing was breaking markdown images and links which use double quotes e.g. `[link text](#"anchor text")`.
This is fixed.
This also makes images inside markdown inline-block as is expected in markdown.