### PR TITLE
Add missing "Off" setting for NAI phrase repetition penalty gensetting

### DIFF
--- a/web/shared/GenerationSettings.tsx
+++ b/web/shared/GenerationSettings.tsx
@@ -654,6 +654,7 @@ const GenSettings: Component<Props & { pane: boolean }> = (props) => {
             { label: 'Medium', value: 'medium' },
             { label: 'Light', value: 'light' },
             { label: 'Very Light', value: 'very_light' },
+            { label: 'None', value: 'off' },
           ]}
           value={props.inherit?.phraseRepPenalty || 'aggressive'}
           service={props.service}

--- a/web/shared/GenerationSettings.tsx
+++ b/web/shared/GenerationSettings.tsx
@@ -654,7 +654,7 @@ const GenSettings: Component<Props & { pane: boolean }> = (props) => {
             { label: 'Medium', value: 'medium' },
             { label: 'Light', value: 'light' },
             { label: 'Very Light', value: 'very_light' },
-            { label: 'None', value: 'off' },
+            { label: 'Off', value: 'off' },
           ]}
           value={props.inherit?.phraseRepPenalty || 'aggressive'}
           service={props.service}


### PR DESCRIPTION
The Phrase Repetition Penalty generation setting was missing the "Off" value, which is used in NAI's new "Cosmic Cube" built-in preset (it instead runs a much higher standard repetition penalty to compensate). This PR just adds that setting so you can recreate that preset in Agnai 1:1.
![image](https://github.com/agnaistic/agnai/assets/92774204/36735fd1-f179-484d-8744-171a24206dfa)
