### PR TITLE
Volume names for self-hosted docker compose

### DIFF
--- a/self-host.docker-compose.yml
+++ b/self-host.docker-compose.yml
@@ -2,9 +2,16 @@ version: '2'
 
 volumes:
   dbdata:
+  dbconfig:
+  appdb:
+  assets:
+  distassets:
+  extras:
+
 
 networks:
   backend:
+
 
 services:
   app:
@@ -19,13 +26,19 @@ services:
       - INITIAL_USER=admin
       - INITIAL_PASSWORD=password
       - JWT_SECRET=self-hosting
-    networks: 
+    volumes:
+      - appdb:/app/db
+      - assets:/app/assets
+      - distassets:/app/dist/assets
+      - extras:/app/extras
+    networks:
       - backend
-    
+
   mongo:
     image: mongo:6
     restart: always
     volumes:
       - dbdata:/data/db
+      - dbconfig:/data/configdb
     networks:
       - backend


### PR DESCRIPTION
Added names for all volumes required by the app for self-hosting:
* all volumes required the agnai app
* additionally dbconfig volume for mongo.

The mongo volume name is not necessary (it's used only for running a cluster), but added a name for it as well, so that compose doesn't create unnecessary unnamed volumes.

After this docker file is executed on an existing setup, the app container will point to the new named volume, so the files from the old volume will need to be copied to the new one.

Fixes #661.