### PR TITLE
Fix for ThirdPartyModel setting in global settings panel 

### DIFF
--- a/web/pages/Settings/components/KoboldAISettings.tsx
+++ b/web/pages/Settings/components/KoboldAISettings.tsx
@@ -1,11 +1,13 @@
-import { Component } from 'solid-js'
+import { Component, createSignal } from 'solid-js'
 import Select from '../../../shared/Select'
 import TextInput from '../../../shared/TextInput'
 import { userStore } from '../../../store'
 import Button from '../../../shared/Button'
+import { ThirdPartyFormat } from '/common/adapters'
 
 const KoboldAISettings: Component = () => {
   const state = userStore()
+  const [format, setFormat] = createSignal(state.user?.thirdPartyFormat)
 
   return (
     <>
@@ -21,14 +23,18 @@ const KoboldAISettings: Component = () => {
         label="Kobold / 3rd-party Format"
         helperText="Re-formats the prompt to the desired output format."
         items={[
+          { label: 'None', value: '' },
           { label: 'Kobold', value: 'kobold' },
-          { label: 'Textgen (Ooba)', value: 'ooba' },
           { label: 'OpenAI', value: 'openai' },
           { label: 'OpenAI (Chat Format)', value: 'openai-chat' },
           { label: 'Claude', value: 'claude' },
+          { label: 'Textgen (Ooba)', value: 'ooba' },
           { label: 'Llama.cpp', value: 'llamacpp' },
+          { label: 'ExLlamaV2', value: 'exllamav2' },
+          { label: 'KoboldCpp', value: 'koboldcpp' },
         ]}
-        value={state.user?.thirdPartyFormat ?? 'kobold'}
+        value={format() ?? 'kobold'}
+        onChange={(ev) => setFormat(ev.value as ThirdPartyFormat)}
       />
       <TextInput
         fieldName="thirdPartyPassword"

--- a/web/shared/GenerationSettings.tsx
+++ b/web/shared/GenerationSettings.tsx
@@ -69,7 +69,7 @@ const GenerationSettings: Component<Props & { onSave: () => void }> = (props) =>
     props.inherit?.service || (services()[0].value as AIAdapter)
   )
   const [format, setFormat] = createSignal(props.inherit?.thirdPartyFormat)
-  const [userFormat, setUserFormat] = createSignal(userState.user?.thirdPartyFormat)
+  const [userFormat, _] = createSignal(userState.user?.thirdPartyFormat)
   const tabs = ['General', 'Prompt', 'Memory', 'Advanced']
   const [tab, setTab] = createSignal(+(search.tab ?? '0'))
 

--- a/web/shared/GenerationSettings.tsx
+++ b/web/shared/GenerationSettings.tsx
@@ -20,7 +20,7 @@ import {
 } from '../../common/adapters'
 import Divider from './Divider'
 import { Toggle } from './Toggle'
-import { chatStore, presetStore, settingStore } from '../store'
+import { chatStore, presetStore, settingStore, userStore } from '../store'
 import PromptEditor, { BasicPromptTemplate } from './PromptEditor'
 import { Card } from './Card'
 import { FormLabel } from './FormLabel'
@@ -57,6 +57,7 @@ type Props = {
 
 const GenerationSettings: Component<Props & { onSave: () => void }> = (props) => {
   const opts = chatStore((s) => s.opts)
+  const userState = userStore()
   const [search, setSearch] = useSearchParams()
 
   const services = createMemo<Option[]>(() => {
@@ -68,6 +69,7 @@ const GenerationSettings: Component<Props & { onSave: () => void }> = (props) =>
     props.inherit?.service || (services()[0].value as AIAdapter)
   )
   const [format, setFormat] = createSignal(props.inherit?.thirdPartyFormat)
+  const [userFormat, setUserFormat] = createSignal(userState.user?.thirdPartyFormat)
   const tabs = ['General', 'Prompt', 'Memory', 'Advanced']
   const [tab, setTab] = createSignal(+(search.tab ?? '0'))
 
@@ -122,11 +124,13 @@ const GenerationSettings: Component<Props & { onSave: () => void }> = (props) =>
               { label: 'ExLlamaV2', value: 'exllamav2' },
               { label: 'KoboldCpp', value: 'koboldcpp' },
             ]}
-            value={props.inherit?.thirdPartyFormat ?? ''}
+            value={props.inherit?.thirdPartyFormat ?? userFormat() ?? ''}
             service={service()}
             format={format()}
             aiSetting={'thirdPartyFormat'}
-            onChange={(ev) => setFormat(ev.value as ThirdPartyFormat)}
+            onChange={(ev) => {
+              setFormat(ev.value as ThirdPartyFormat)
+            }}
           />
 
           <RegisteredSettings service={service()} inherit={props.inherit} />


### PR DESCRIPTION
thirdPartyModel wasn't being stored properly in the user store.  The default preset wasn't pulling correctly from the user store, either.  This seems to fix it.