### PR TITLE
Fixes characters with hidden tags still appearing in the character list

### DIFF
--- a/web/pages/Character/CharacterList.tsx
+++ b/web/pages/Character/CharacterList.tsx
@@ -69,6 +69,7 @@ const CharacterList: Component = () => {
       .slice()
       .filter((ch) => ch.name.toLowerCase().includes(search().toLowerCase().trim()))
       .filter((ch) => tags.filter.length === 0 || ch.tags?.some((t) => tags.filter.includes(t)))
+      .filter((ch) => !ch.tags || !ch.tags.some((t) => tags.hidden.includes(t)))
       .sort(getSortFunction(field, dir))
     return sorted
   })
@@ -80,6 +81,7 @@ const CharacterList: Component = () => {
       .slice()
       .filter((ch) => ch.name.toLowerCase().includes(search().toLowerCase().trim()))
       .filter((ch) => tags.filter.length === 0 || ch.tags?.some((t) => tags.filter.includes(t)))
+      .filter((ch) => !ch.tags || !ch.tags.some((t) => tags.hidden.includes(t)))
       .sort(getSortFunction(field, dir))
     return sorted
   })


### PR DESCRIPTION
Re-adds [this line](https://github.com/agnaistic/agnai/commit/62386fab6027cb17efc987a7c2b4ec2554e973c5#diff-a3adc4c94c70d0c45c919c983bc13ce1c1d5f1868507e3e635c3e4db94e22dc6L235) that seems like it might have been accidentally removed in #697.  This fixes the tag exclusion filter not working.