### PR TITLE
Fix mem entry ordering bugs + refactor

### DIFF
--- a/common/memory.ts
+++ b/common/memory.ts
@@ -177,21 +177,23 @@ async function findMatchWithLowestAge(
 }
 
 function findFirstMatchingLineNumber(keyword: string, history: string[]) {
+  const searchPattern = createRegexForKeyword(keyword)
+
   let lineNumber = 0
   for (const line of history) {
-    if (wildcardMatch(keyword, line)) return lineNumber
+    if (searchPattern.test(line)) return lineNumber
     lineNumber++
   }
 }
 
-function wildcardMatch(keyword: string, text: string) {
+function createRegexForKeyword(keyword: string) {
   const pattern = keyword
     .trim()
     .replace(/[\\^$+.()|[\]{}_]/g, '') // escape all special chars except * and ?
     .replace(/\*/g, '\\w*') // enable searching by *
     .replace(/\?/g, '\\w') // enable searching by ?
 
-  return text.match(new RegExp(`\\b(${pattern})\\b`, 'giu'))
+  return new RegExp(`\\b(${pattern})\\b`, 'giu')
 }
 
 async function getMatchesWithinBudget(matches: Match[], ctx: MemoryPromptContext) {

--- a/common/memory.ts
+++ b/common/memory.ts
@@ -22,14 +22,19 @@ export type MemoryPrompt = {
 }
 
 type Match = {
-  /** The order in which is was found in the book's entry list */
-  id: number
-
   /** The position within the prompt that it was found. Larger means closer to the end */
   index: number
   entry: AppSchema.MemoryEntry
   tokens: number
   text: string
+}
+
+type MemoryPromptContext = {
+  bot: string
+  sender: string
+  depth: number
+  budget: number
+  encoder: TokenCounter
 }
 
 export type CharacterBook = {
@@ -65,115 +70,140 @@ export type CharacterBook = {
 
 type CharacterBookEntry = CharacterBook['entries'][number]
 
-/**
- * When determine the insertion order of an entry:
- * - Highest priority wins
- * - If there is a priority tie, entry that is "most recently referred to" wins
- * - If there is a tie due to using the same keyword, the earliest entry in the book wins
- */
+export async function buildMemoryPrompt(opts: MemoryOpts, encoder: TokenCounter): Promise<string> {
+  const ctx = getMemoryPromptContext(opts, encoder)
+  if (!ctx) return ''
 
-export const MEMORY_PREFIX = 'Facts: '
+  const entries = getEnabledEntriesFromBooks(opts.books)
 
-export async function buildMemoryPrompt(
+  const matches = await findAllMatches(entries, opts.lines, ctx)
+  matches.sort(byPriorityThenIndex)
+
+  const included = await getMatchesWithinBudget(matches, ctx)
+  included.sort(byWeightThenIndex)
+
+  let prompt = included
+    .map(({ text }) => text)
+    .reverse()
+    .join('')
+
+  // do not append extra '\n' at the end
+  if (prompt.endsWith('\n')) prompt = prompt.slice(0, -'\n'.length)
+
+  return prompt
+}
+
+function getMemoryPromptContext(
   opts: MemoryOpts,
   encoder: TokenCounter
-): Promise<MemoryPrompt | undefined> {
-  const { chat, settings, members, char, lines, books } = opts
-
-  if (!books || !books.length) return
-  const sender =
-    opts.impersonate?.name || members.find((mem) => mem.userId === chat.userId)?.handle || 'You'
-
-  const depth = settings?.memoryDepth || defaultPresets.basic.memoryDepth || Infinity
-  const memoryBudget = settings?.memoryContextLimit || defaultPresets.basic.memoryContextLimit
-  // const reveseWeight = settings?.memoryReverseWeight ?? defaultPresets.basic.memoryReverseWeight
-
+): MemoryPromptContext | undefined {
+  const depth = opts.settings?.memoryDepth || defaultPresets.basic.memoryDepth || Infinity
   if (isNaN(depth) || depth <= 0) return
 
-  const finalPrompts: string[] = []
-  const finalEntries: Match[] = []
-  let finalTokens = await encoder(MEMORY_PREFIX)
+  const budget = opts.settings?.memoryContextLimit || defaultPresets.basic.memoryContextLimit
 
+  const bot = opts.char.name
+  const sender =
+    opts.impersonate?.name ||
+    opts.members.find((mem) => mem.userId === opts.chat.userId)?.handle ||
+    'You'
+
+  return {
+    bot,
+    sender,
+    depth,
+    budget,
+    encoder,
+  }
+}
+
+function getEnabledEntriesFromBooks(books: (AppSchema.MemoryBook | undefined)[] | undefined) {
+  if (!books) return []
+
+  const entries = []
   for (const book of books) {
     if (!book) continue
 
-    const matches: Match[] = []
-
-    let id = 0
-    const combinedText = lines.slice().reverse().slice(0, depth).join(' ').toLocaleLowerCase()
-    const reversed = prep(combinedText)
-
     for (const entry of book.entries) {
       if (!entry.enabled) continue
-
-      let index = -1
-      for (const keyword of entry.keywords) {
-        try {
-          const txt = `\\b(${prep(keyword.trim())})\\b`
-          const re = new RegExp(txt, 'gi')
-          const result = re.exec(reversed)
-          if (index === -1 && result !== null) {
-            index = result.index
-          }
-        } catch (ex) {
-          /**
-           * @todo handle failures properly
-           */
-        }
-      }
-
-      if (index > -1) {
-        const text = entry.entry.replace(BOT_REPLACE, char.name).replace(SELF_REPLACE, sender)
-        const tokens = await encoder(text)
-        matches.push({ index, entry, id: ++id, tokens, text })
-      }
+      entries.push(entry)
     }
-
-    matches.sort(byPriorityThenIndex)
-
-    const entries = matches.reduce(
-      (prev, curr) => {
-        if (prev.budget >= memoryBudget) return prev
-        if (prev.budget + curr.tokens > memoryBudget) return prev
-
-        prev.budget += curr.tokens
-        prev.list.push(curr)
-        return prev
-      },
-      { list: [] as Match[], budget: finalTokens }
-    )
-
-    const prompt = entries.list
-      .map(({ text }) => text)
-      .reverse()
-      .join('\n')
-
-    finalPrompts.push(prompt)
-    finalEntries.push(...entries.list)
-    finalTokens += entries.budget
   }
+  return entries
+}
+
+async function findAllMatches(
+  entries: AppSchema.MemoryEntry[],
+  lines: string[],
+  ctx: MemoryPromptContext
+) {
+  const matches: Match[] = []
+  const history = lines.slice(-ctx.depth).join(' ').toLowerCase()
+
+  for (const entry of entries) {
+    const match = await findLastMatch(entry, history, ctx)
+    if (match) matches.push(match)
+  }
+  return matches
+}
+
+async function findLastMatch(
+  entry: AppSchema.MemoryEntry,
+  history: string,
+  ctx: MemoryPromptContext
+): Promise<Match | undefined> {
+  let highestIndex = -1
+
+  for (const keyword of entry.keywords) {
+    const index = history.lastIndexOf(keyword.toLowerCase())
+    if (index < 0) continue
+
+    highestIndex = Math.max(highestIndex, index)
+  }
+
+  if (highestIndex < 0) return
+
+  // append the newline now for the token count to match
+  const text = entry.entry
+    .replace(BOT_REPLACE, ctx.bot)
+    .replace(SELF_REPLACE, ctx.sender)
+    .concat('\n')
 
   return {
-    prompt: finalPrompts.join('\n'),
-    entries: finalEntries, // entries.list,
-    tokens: finalTokens, // entries.budget,
+    index: highestIndex,
+    entry,
+    tokens: await ctx.encoder(text),
+    text,
   }
 }
 
-function byPriorityThenIndex(
-  { id: lid, index: li, entry: l }: Match,
-  { id: rid, index: ri, entry: r }: Match
-) {
-  if (l.weight !== r.weight) return l.weight < r.weight ? 1 : -1
-  if (li !== ri) return li > ri ? -1 : 1
-  return lid > rid ? 1 : lid === rid ? 0 : -1
+async function getMatchesWithinBudget(matches: Match[], ctx: MemoryPromptContext) {
+  let allowed: Match[] = []
+  let tokensUsed = 0
+
+  for (const match of matches) {
+    if (tokensUsed + match.tokens >= ctx.budget) break
+
+    allowed.push(match)
+    tokensUsed += match.tokens
+  }
+  return allowed
 }
 
-function prep(str: string, safe?: boolean) {
-  let next = ''
-  for (let i = str.length - 1; i >= 0; i--) next += str[i]
-  if (!safe) return next
-  return next.toLowerCase().replace(/\-/g, '\\-')
+function byPriorityThenIndex({ index: li, entry: l }: Match, { index: ri, entry: r }: Match) {
+  // higher priority wins
+  if (l.priority !== r.priority) return l.priority > r.priority ? -1 : 1
+  // higher index wins
+  if (li !== ri) return li > ri ? -1 : 1
+  return 0
+}
+
+function byWeightThenIndex({ index: li, entry: l }: Match, { index: ri, entry: r }: Match) {
+  // higher weight wins
+  if (l.weight !== r.weight) return l.weight > r.weight ? -1 : 1
+  // higher index wins
+  if (li !== ri) return li > ri ? -1 : 1
+  return 0
 }
 
 export function characterBookToNative(cb: CharacterBook): AppSchema.MemoryBook {

--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -399,8 +399,7 @@ export async function buildPromptParts(
   if (replyAs.characterBook) books.push(replyAs.characterBook)
   if (opts.book) books.push(opts.book)
 
-  const memory = await buildMemoryPrompt({ ...opts, books, lines: linesForMemory }, encoder)
-  parts.memory = memory?.prompt
+  parts.memory = await buildMemoryPrompt({ ...opts, books, lines: linesForMemory }, encoder)
 
   const supplementary = getSupplementaryParts(opts, replyAs)
   parts.ujb = supplementary.ujb

--- a/instructions/memory.md
+++ b/instructions/memory.md
@@ -11,13 +11,20 @@ You can also provide `priority` and `weight`, but we'll get to that later.
 
 - Keywords:
   - These are words that "trigger" the memory to be inserted into your prompt.
-  - E.g. `drink, thrist, hydrate, hydrate`
+  - E.g. `drink, thrist, hydrate, water`
 - Entry:
   - This is the text that is inserted into your prompt when one of your keywords is found.
   - E.g. `{{user}}'s favourite drink is red cordial on the rocks`
 
 Your generation settings will have a **Memory Depth**. This is the maximum number of chat messages that Agnai will scan for keywords.  
 It is important to remember this all happens in your browser.
+
+You can use `*` (matching any character zero or more times) and `?` (matching a single character) wildcards in your keywords, e.g.
+
+- `book*` will match `book`, `books`, `booking`, but not `ebook`
+- `?book` will match `ebook`, but not `book`
+
+In particular the keyword `*` matches anything, as long as Memory settings allow for it.
 
 ### Why is it important to remember this occurs in the browser?
 

--- a/tests/__snapshots__/prompt.spec.js.snap
+++ b/tests/__snapshots__/prompt.spec.js.snap
@@ -155,6 +155,21 @@ MainChar: first
 OtherBot:"
 `;
 
+exports[`Prompt building will include two memories by weight when triggered 1`] = `
+"OtherBot's Persona: OtherBot replies a lot
+
+Scenario: MAIN MainChar
+Facts:ENTRY ONE
+ENTRY TWO
+How OtherBot speaks: SAMPLECHAT OtherBot
+
+<START>
+MainChar: FIRST
+ChatOwner: 10-TRIGGER
+ChatOwner: 1-TRIGGER
+OtherBot:"
+`;
+
 exports[`Prompt building will include ujb when omitted from gaslight 1`] = `
 Object {
   "lines": Array [
@@ -195,27 +210,10 @@ OtherBot:",
 }
 `;
 
-exports[`Prompt building will include will two memories by weight when triggered 1`] = `
-"OtherBot's Persona: OtherBot replies a lot
-
-Scenario: MAIN MainChar
-Facts:ENTRY ONE
-ENTRY TWO
-How OtherBot speaks: SAMPLECHAT OtherBot
-
-<START>
-MainChar: FIRST
-ChatOwner: 10-TRIGGER
-ChatOwner: 1-TRIGGER
-OtherBot:"
-`;
-
 exports[`Prompt building will not use other character book 1`] = `
 "OtherBot's Persona: OtherBot replies a lot
 
 Scenario: MAIN MainChar
-Facts:
-
 How OtherBot speaks: SAMPLECHAT OtherBot
 
 <START>
@@ -266,6 +264,32 @@ ChatOwner: 20-TRIGGER
 OtherBot:"
 `;
 
+exports[`Prompt building will put char book entries with higher weight after mem book entries 1`] = `
+"MainChar's Persona: MainCharacter talks a lot
+
+Scenario: MAIN MainChar
+Facts:ENTRY 10
+ENTRY 20
+How MainChar speaks: SAMPLECHAT MainChar
+
+<START>
+ChatOwner: TRIGGER
+MainChar:"
+`;
+
+exports[`Prompt building will put mem book entries with higher weight after char book entries 1`] = `
+"MainChar's Persona: MainCharacter talks a lot
+
+Scenario: MAIN MainChar
+Facts:ENTRY 10
+ENTRY 20
+How MainChar speaks: SAMPLECHAT MainChar
+
+<START>
+ChatOwner: TRIGGER
+MainChar:"
+`;
+
 exports[`Prompt building will use correct placeholders in scenario and sample chat 1`] = `
 "OtherBot's Persona: OtherBot replies a lot
 
@@ -282,7 +306,6 @@ exports[`Prompt building will use currently speaking character book 1`] = `
 
 Scenario: MAIN MainChar
 Facts:ENTRY
-
 How OtherBot speaks: SAMPLECHAT OtherBot
 
 <START>

--- a/tests/__snapshots__/prompt.spec.js.snap
+++ b/tests/__snapshots__/prompt.spec.js.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Prompt building will allow using using Unicode characters in keywords 1`] = `
+"MainChar's Persona: MainCharacter talks a lot
+
+Scenario: MAIN MainChar
+How MainChar speaks: SAMPLECHAT MainChar
+
+<START>
+ChatOwner: 🤣
+MainChar:"
+`;
+
+exports[`Prompt building will allow using wildcards in keywords 1`] = `
+"MainChar's Persona: MainCharacter talks a lot
+
+Scenario: MAIN MainChar
+Facts:ENTRY 1
+How MainChar speaks: SAMPLECHAT MainChar
+
+<START>
+ChatOwner: ebooks
+MainChar:"
+`;
+
 exports[`Prompt building will build a basic prompt 1`] = `
 "OtherBot's Persona: OtherBot replies a lot
 
@@ -22,6 +45,18 @@ How MainChar speaks: SAMPLECHAT MainChar
 MainChar: FIRST
 MainChar: ORIGINAL
 MainChar:"
+`;
+
+exports[`Prompt building will disallow injecting arbitrary regexes 1`] = `
+"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa's Persona: MainCharacter talks a lot
+
+Scenario: MAIN aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+Facts:ENTRY 1
+How aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa speaks: SAMPLECHAT aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+<START>
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: books
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:"
 `;
 
 exports[`Prompt building will exclude lowest priority memory to fit in budget 1`] = `

--- a/tests/__snapshots__/prompt.spec.js.snap
+++ b/tests/__snapshots__/prompt.spec.js.snap
@@ -1,16 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Prompt building will allow using using Unicode characters in keywords 1`] = `
-"MainChar's Persona: MainCharacter talks a lot
-
-Scenario: MAIN MainChar
-How MainChar speaks: SAMPLECHAT MainChar
-
-<START>
-ChatOwner: 🤣
-MainChar:"
-`;
-
 exports[`Prompt building will allow using wildcards in keywords 1`] = `
 "MainChar's Persona: MainCharacter talks a lot
 

--- a/tests/prompt.spec.ts
+++ b/tests/prompt.spec.ts
@@ -290,23 +290,6 @@ This is how {{char}} should talk: {{example_dialogue}}`,
     expect(actual.template.parsed).toMatchSnapshot()
   })
 
-  it('will allow using using Unicode characters in keywords', async () => {
-    const char = {
-      ...main,
-      characterBook: toBook('main char book', [toEntry(['🤣'], '🤣'), toEntry(['🤬'], '🤬')]),
-    }
-
-    const actual = await build([toMsg('🤣')], {
-      char: char,
-      replyAs: char,
-      settings: { memoryDepth: 100 },
-    })
-
-    expect(actual.template.parsed).to.include('🤣')
-    expect(actual.template.parsed).not.to.include('🤬')
-    expect(actual.template.parsed).toMatchSnapshot()
-  })
-
   it('will disallow injecting arbitrary regexes', async () => {
     const char = {
       ...main,


### PR DESCRIPTION
Refactored memory prompt building, fixed some smaller bugs:
- fixed entry inclusion relying on weights instead of priorities
- fixed incorrect sorting of entries in various scenarios
- removed reversing the strings for searches
- fixed a problem with token budget counter not counting newline characters
- fixed problems with some memory tests passing incorrectly
- removed some return values in `buildMemoryPrompt` that weren't actually used anywhere
- escaped regexp special characters to avoid regexp injection
- allowed usage of `*` and `?` wildcards in keywords

Changes that may affect users:
- `*` and `?` wildcards allow keywords to use partial matching (e.g. `book*`)
- `*` keyword always matches
- if priority or weight are tied, rather than relying on absolute position of a match, it uses the age of the matched message