### PR TITLE
fix: wide imgs breaking ui with avatar wrap off

### DIFF
--- a/web/pages/Chat/components/Message.tsx
+++ b/web/pages/Chat/components/Message.tsx
@@ -302,7 +302,7 @@ const Message: Component<MessageProps> = (props) => {
                 </Match>
               </Switch>
             </span>
-            <div ref={avatarRef}>
+            <div ref={avatarRef} class={user.ui.imageWrap ? '' : 'overflow-hidden'}>
               <Switch>
                 <Match when={props.msg.adapter === 'image'}>
                   <div class="flex flex-wrap gap-2">
@@ -338,7 +338,7 @@ const Message: Component<MessageProps> = (props) => {
                 </Match>
                 <Match when={!edit() && content().type !== 'waiting'}>
                   <p
-                    class={`rendered-markdown px-1 ${content().class}`}
+                    class={`rendered-markdown pr-1 ${content().class}`}
                     data-bot-message={!props.msg.userId}
                     data-user-message={!!props.msg.userId}
                     innerHTML={content().message}


### PR DESCRIPTION
When avatar wrap is off, fix bug where wide images would cause the avatar column to go up to 10000px height.

This is due to the avatar float causing the message text element's width to contain the avatar column, so when images reach 100% of their container, this 100% does not exclude the avatar-column width. We can force the message text element to be adjacent to the avatar column with `overflow-hidden` (for some reason), but we only include this when wrap around is off, or it obviously cancels the wraparound.

Note: I couldn't test this extensively due to errors when running `npm run start`, so I tested this with Inspect Element in agnai.chat.

```
[api] [2023-11-25T08:22:53Z] ERROR (app/4123191): Unhandled rejection
[api]     err: "read ECONNRESET"
```