### PR TITLE
Add stop_sequences to kobold presets, add trim_stop option to koboldcpp presets

### DIFF
--- a/common/adapters.ts
+++ b/common/adapters.ts
@@ -311,7 +311,8 @@ export const adapterSettings: {
   presencePenalty: ['openai', 'kobold', 'novel', 'openai-chat'],
   streamResponse: ['openai', 'kobold', 'novel', 'claude', 'ooba', 'agnaistic', 'openai-chat'],
   openRouterModel: ['openrouter'],
-  stopSequences: ['ooba', 'agnaistic', 'novel', 'mancer', 'llamacpp', 'horde', 'exllamav2'],
+  stopSequences: ['ooba', 'agnaistic', 'novel', 'mancer', 'llamacpp', 'horde', 'exllamav2', 'kobold'],
+  trimStop: ['koboldcpp'],
 
   addBosToken: ['ooba', 'agnaistic'],
   banEosToken: ['ooba', 'agnaistic'],
@@ -380,6 +381,7 @@ export const settingLabels: { [key in keyof PresetAISettings]: string } = {
   prefill: 'Bot response prefilling',
   phraseRepPenalty: 'Phrase Repetition Penality',
   stopSequences: 'Stop Sequences',
+  trimStop: 'Trim Stop Sequences',
   mirostatTau: 'Mirostat Tau',
   mirostatLR: 'Mirostat LR',
 }

--- a/common/presets.ts
+++ b/common/presets.ts
@@ -58,6 +58,7 @@ export const presetValidator = {
   phraseRepPenalty: 'string?',
 
   stopSequences: ['string?'],
+  trimStop: 'boolean?',
   thirdPartyUrl: 'string?',
   thirdPartyFormat: [...THIRDPARTY_FORMATS, null],
   thirdPartyUrlNoSuffix: 'boolean?',

--- a/common/types/schema.ts
+++ b/common/types/schema.ts
@@ -485,6 +485,7 @@ export namespace AppSchema {
     banEosToken?: boolean
     earlyStopping?: boolean
     stopSequences?: string[]
+    trimStop?: boolean
 
     order?: number[]
     disabledSamplers?: number[]

--- a/srv/adapter/ooba.ts
+++ b/srv/adapter/ooba.ts
@@ -160,6 +160,7 @@ export function getThirdPartyPayload(opts: AdapterProps, stops: string[] = []) {
       top_a: gen.topA,
       typical: gen.typicalP,
       stop_sequence: getStoppingStrings(opts, stops),
+      trim_stop: gen.trimStop,
       rep_pen_range: gen.repetitionPenaltyRange,
       rep_pen_slope: gen.repetitionPenaltySlope,
     }

--- a/web/shared/GenerationSettings.tsx
+++ b/web/shared/GenerationSettings.tsx
@@ -446,6 +446,16 @@ const GeneralSettings: Component<
           disabled={props.disabled}
         />
         <StoppingStrings inherit={props.inherit} service={props.service} format={props.format} />
+        <Toggle
+          fieldName="trimStop"
+          label="Trim Stop Sequences"
+          helperText="Trim Stop Sequences from the AI's response. Does not work with Streaming responses."
+          value={props.inherit?.trimStop ?? false}
+          disabled={props.disabled}
+          service={props.service}
+          format={props.format}
+          aiSetting={'trimStop'}
+        />
         <PhraseBias inherit={props.inherit} service={props.service} format={props.format} />
       </Card>
     </div>


### PR DESCRIPTION
This commit adds the ability to add stop sequences to the UI for kobold presets. The stop sequences themselves were already there but filtered from the UI.

It also adds the ability to toggle trim_stop, which is a koboldcpp feature that tells the model to remove any stop sequences from the output before sending. (Default behavior is to stop at the stop sequence but still send it).

I ran prettier on this but it changes the array in common/adapters.ts to look different than the rest of the arrays in that file, so I discarded that change. Prettier also makes changes to a file that I didn't touch (common/dummy.ts) so I discarded changes to that file as well.