### PR TITLE
Add Impersonation button next to the chat input for quick access

### DIFF
--- a/web/pages/Chat/components/InputBar.tsx
+++ b/web/pages/Chat/components/InputBar.tsx
@@ -14,7 +14,7 @@ import { AppSchema } from '../../../../common/types/schema'
 import Button, { LabelButton } from '../../../shared/Button'
 import { DropMenu } from '../../../shared/DropMenu'
 import TextInput from '../../../shared/TextInput'
-import { chatStore, toastStore, userStore } from '../../../store'
+import { chatStore, toastStore, userStore, settingStore, characterStore } from '../../../store'
 import { msgStore } from '../../../store'
 import { SpeechRecognitionRecorder } from './SpeechRecognitionRecorder'
 import { Toggle } from '/web/shared/Toggle'
@@ -29,6 +29,7 @@ import { EVENTS, events } from '/web/emitter'
 import { AutoComplete } from '/web/shared/AutoComplete'
 import FileInput, { FileInputResult, getFileAsDataURL } from '/web/shared/FileInput'
 import { embedApi } from '/web/store/embeddings'
+import AvatarIcon from '/web/shared/AvatarIcon'
 
 const InputBar: Component<{
   chat: AppSchema.Chat
@@ -54,6 +55,7 @@ const InputBar: Component<{
     canCaption: s.canImageCaption,
   }))
   const chats = chatStore((s) => ({ replyAs: s.active?.replyAs }))
+  const chars = characterStore()
 
   useEffect(() => {
     const listener = (text: string) => {
@@ -222,6 +224,24 @@ const InputBar: Component<{
         </div>
       </Show>
 
+      <div class="flex items-center">
+        <a
+          href="#"
+          role="button"
+          aria-label="Open impersonation menu"
+          class="icon-button"
+          onClick={() => {
+            settingStore.toggleImpersonate(true)
+            //if (menu.showMenu) settingStore.closeMenu()
+          }}
+        >
+          <AvatarIcon
+            avatarUrl={chars.impersonating?.avatar || user.profile?.avatar}
+            format={{ corners: 'circle', size: 'sm' }}
+            class="mr-2"
+          />
+        </a>
+      </div>
       <Show when={complete()}>
         <AutoComplete
           options={completeOpts()}


### PR DESCRIPTION
This PR add a button for Impersonating a Character next to the chat input for quick access.

When using own profile (without avatar) or impersonating a character that's doesn't have an image associated:
<img width="209" alt="image" src="https://github.com/agnaistic/agnai/assets/501695/b8e88243-d809-4c58-ae57-bb9b321f63ef">
When Impersonating a character (with image associated to it):
<img width="209" alt="image" src="https://github.com/agnaistic/agnai/assets/501695/d73880cc-67bf-47d2-8707-9b6173691a40">

NOTE: I left `//if (menu.showMenu) settingStore.closeMenu()` commented since I'm not sure if it's needed in this case.