### PR TITLE
feat: ui setting: dotted line at ctx window limit

### DIFF
--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -432,17 +432,23 @@ export async function buildPromptParts(
 
   if (opts.userEmbeds) {
     const embeds = opts.userEmbeds.map((line) => line.text)
-    const fit = (
-      await fillPromptWithLines(encoder, opts.settings?.memoryUserEmbedLimit || 500, '', embeds)
-    ).adding
+    const { adding: fit } = await fillPromptWithLines(
+      encoder,
+      opts.settings?.memoryUserEmbedLimit || 500,
+      '',
+      embeds
+    )
     parts.userEmbeds = fit
   }
 
   if (opts.chatEmbeds) {
     const embeds = opts.chatEmbeds.map((line) => `${line.name}: ${line.text}`)
-    const fit = (
-      await fillPromptWithLines(encoder, opts.settings?.memoryChatEmbedLimit || 500, '', embeds)
-    ).adding
+    const { adding: fit } = await fillPromptWithLines(
+      encoder,
+      opts.settings?.memoryChatEmbedLimit || 500,
+      '',
+      embeds
+    )
     parts.chatEmbeds = fit
   }
 
@@ -556,7 +562,7 @@ export async function getLinesForPrompt(
 
   const history = messages.slice().sort(sortMessagesDesc).map(formatMsg)
 
-  const lines = (await fillPromptWithLines(encoder, maxContext, '', history)).adding
+  const { adding: lines } = await fillPromptWithLines(encoder, maxContext, '', history)
 
   if (opts.trimSentences) {
     return lines.map(trimSentence)

--- a/common/template-parser.ts
+++ b/common/template-parser.ts
@@ -117,7 +117,12 @@ export type TemplateOpts = {
 export async function parseTemplate(
   template: string,
   opts: TemplateOpts
-): Promise<{ parsed: string; inserts: Map<number, string>; length?: number }> {
+): Promise<{
+  parsed: string
+  inserts: Map<number, string>
+  length?: number
+  linesAddedCount: number
+}> {
   if (opts.limit) {
     opts.limit.output = {}
   }
@@ -136,6 +141,7 @@ export async function parseTemplate(
   readInserts(template, opts, ast)
   let output = render(template, opts, ast)
   let unusedTokens = 0
+  let linesAddedCount = 0
 
   if (opts.limit && opts.limit.output) {
     // const lastIndex = Object.keys(opts.limit.output).reduce((prev, curr) => {
@@ -157,8 +163,9 @@ export async function parseTemplate(
         opts.lowpriority
       )
       unusedTokens = filled.unusedTokens
-      const trimmed = filled.adding.reverse()
+      const trimmed = filled.adding.slice().reverse()
       output = output.replace(id, trimmed.join('\n'))
+      linesAddedCount += filled.linesAddedCount
     }
 
     // Adding the low priority blocks if we still have the budget for them,
@@ -181,6 +188,7 @@ export async function parseTemplate(
     parsed: result,
     inserts: opts.inserts ?? new Map(),
     length: await opts.limit?.encoder?.(result),
+    linesAddedCount,
   }
 }
 

--- a/common/types/ui.ts
+++ b/common/types/ui.ts
@@ -66,6 +66,7 @@ export type UISettings = {
   chatWidth?: ChatWidth
   trimSentences?: boolean
   logPromptsToBrowserConsole: boolean
+  contextWindowLine: boolean
 
   dark: CustomUI
   light: CustomUI
@@ -117,6 +118,7 @@ export const defaultUIsettings: UISettings = {
   chatWidth: 'full',
   chatAvatarMode: true,
   logPromptsToBrowserConsole: false,
+  contextWindowLine: false,
   imageWrap: false,
 
   light: {

--- a/tests/__snapshots__/placeholder.spec.js.snap
+++ b/tests/__snapshots__/placeholder.spec.js.snap
@@ -4,6 +4,7 @@ exports[`Placeholder tests will not include duplicates in {{all_personalities}} 
 Object {
   "inserts": Map {},
   "length": undefined,
+  "linesAddedCount": 0,
   "parsed": "OtherBot replies a lot
 
 MainChar's personality: MainCharacter talks a lot",

--- a/tests/__snapshots__/prompt.spec.js.snap
+++ b/tests/__snapshots__/prompt.spec.js.snap
@@ -221,6 +221,7 @@ Object {
   "template": Object {
     "inserts": Map {},
     "length": 48,
+    "linesAddedCount": 2,
     "parsed": "GASLIGHT TEMPLATE
 ChatOwner
 OtherBot

--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -78,6 +78,7 @@ const ChatDetail: Component = () => {
     loaded: s.loaded,
     opts: s.opts,
     ready: s.allChars.list.length > 0 && (s.active?.char?._id || 'no-id') in s.allChars.map,
+    linesAddedCount: s.prompt?.template.linesAddedCount,
   }))
 
   const msgs = msgStore((s) => ({
@@ -132,6 +133,7 @@ const ChatDetail: Component = () => {
   const [showOpts, setShowOpts] = createSignal(false)
   const [ooc, setOoc] = createSignal<boolean>()
   const [showHiddenEvents, setShowHiddenEvents] = createSignal(false)
+  const [linesAddedCount, setLinesAddedCount] = createSignal<number | undefined>(undefined)
 
   const chatMsgs = createMemo(() => {
     const self = user.profile
@@ -163,6 +165,16 @@ const ChatDetail: Component = () => {
       if (msg.event === 'hidden' && !doShowHiddenEvents) return false
       return true
     })
+  })
+
+  createEffect(() => {
+    chatStore.computePrompt(msgs.msgs[msgs.msgs.length - 1], false)
+    setLinesAddedCount(chats.linesAddedCount)
+  })
+
+  const firstInsertedMsgIndex = createMemo(() => {
+    const linesAdded = linesAddedCount()
+    if (linesAdded) return chatMsgs().length - 1 - linesAdded
   })
 
   createEffect(() => {
@@ -588,6 +600,7 @@ const ChatDetail: Component = () => {
                                 ? msgs.speaking.status
                                 : undefined
                             }
+                            firstInserted={i() === firstInsertedMsgIndex()}
                           >
                             {isOwner() &&
                               retries()?.list?.length! > 1 &&

--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -600,7 +600,7 @@ const ChatDetail: Component = () => {
                                 ? msgs.speaking.status
                                 : undefined
                             }
-                            firstInserted={i() === firstInsertedMsgIndex()}
+                            firstInserted={i === firstInsertedMsgIndex()}
                           >
                             {isOwner() &&
                               retries()?.list?.length! > 1 &&

--- a/web/pages/Chat/components/Message.css
+++ b/web/pages/Chat/components/Message.css
@@ -119,3 +119,12 @@ em {
     max-width: calc(100% - 16px - theme('width.24'));
   }
 }
+
+.first-in-ctx-window::before {
+  content: '';
+  border-top: 2px dotted var(--bg-600);
+  width: 100%;
+  position: absolute;
+  top: -5px;
+  left: 0;
+}

--- a/web/pages/Chat/components/Message.tsx
+++ b/web/pages/Chat/components/Message.tsx
@@ -67,6 +67,7 @@ type MessageProps = {
   showHiddenEvents?: boolean
   textBeforeGenMore?: string
   voice?: VoiceState
+  firstInserted?: boolean
 }
 
 const anonNames = new Map<string, number>()
@@ -145,9 +146,12 @@ const Message: Component<MessageProps> = (props) => {
 
   const format = createMemo(() => ({ size: user.ui.avatarSize, corners: user.ui.avatarCorners }))
 
+  const contextWindowIndicatorClass = () =>
+    props.firstInserted && user.ui.contextWindowLine ? 'first-in-ctx-window' : ''
+
   return (
     <div
-      class="flex w-full rounded-md px-2 py-2 pr-2 sm:px-4"
+      class={'flex w-full rounded-md px-2 py-2 pr-2 sm:px-4 ' + contextWindowIndicatorClass()}
       style={bgStyles()}
       data-sender={props.msg.characterId ? 'bot' : 'user'}
       data-bot={props.msg.characterId ? ctx.char?.name : ''}
@@ -414,7 +418,7 @@ const MessageOptions: Component<{
     <div class="flex items-center gap-3 text-sm">
       <Show when={props.chatEditing && props.msg.characterId && props.msg.adapter !== 'image'}>
         <div
-          onClick={() => !props.partial && chatStore.showPrompt(props.msg)}
+          onClick={() => !props.partial && chatStore.computePrompt(props.msg, true)}
           class="icon-button prompt-btn"
           classList={{ disabled: !!props.partial }}
         >

--- a/web/pages/Chat/components/Message.tsx
+++ b/web/pages/Chat/components/Message.tsx
@@ -146,18 +146,18 @@ const Message: Component<MessageProps> = (props) => {
 
   const format = createMemo(() => ({ size: user.ui.avatarSize, corners: user.ui.avatarCorners }))
 
-  const contextWindowIndicatorClass = () =>
-    props.firstInserted && user.ui.contextWindowLine ? 'first-in-ctx-window' : ''
-
   return (
     <div
-      class={'flex w-full rounded-md px-2 py-2 pr-2 sm:px-4 ' + contextWindowIndicatorClass()}
+      class={'flex w-full rounded-md px-2 py-2 pr-2 sm:px-4'}
       style={bgStyles()}
       data-sender={props.msg.characterId ? 'bot' : 'user'}
       data-bot={props.msg.characterId ? ctx.char?.name : ''}
       data-user={props.msg.userId ? state.memberIds[props.msg.userId]?.handle : ''}
       data-last={props.last?.toString()}
       data-lastsplit="true"
+      classList={{
+        'first-in-ctx-window': user.ui.contextWindowLine && props.firstInserted,
+      }}
     >
       <div class={`flex w-full ${opacityClass}`}>
         <div class={`flex h-fit w-full select-text flex-col gap-1`}>

--- a/web/pages/Chat/components/PromptModal.tsx
+++ b/web/pages/Chat/components/PromptModal.tsx
@@ -27,7 +27,7 @@ const PromptModal: Component = () => {
 
   return (
     <Modal
-      show={!!state.prompt}
+      show={!!state.prompt?.shown}
       close={chatStore.closePrompt}
       title="Message Prompt"
       maxWidth="half"

--- a/web/pages/Settings/UISettings.tsx
+++ b/web/pages/Settings/UISettings.tsx
@@ -131,6 +131,14 @@ const UISettings: Component = () => {
         onChange={(ev) => userStore.saveUI({ mobileSendOnEnter: ev })}
       />
 
+      <Toggle
+        fieldName="contextWindowLine"
+        label="Show context window delineator"
+        helperText="Shows a dotted line above which messages are no longer inserted in the prompt"
+        value={state.ui.contextWindowLine}
+        onChange={(ev) => userStore.saveUI({ contextWindowLine: ev })}
+      />
+
       <Select
         fieldName="chatMode"
         label="View Mode"

--- a/web/store/chat.ts
+++ b/web/store/chat.ts
@@ -519,7 +519,7 @@ export const chatStore = createStore<ChatState>('chat', {
       await api.get(`/chat/${chatId}/summary`)
     },
 
-    async showPrompt({ active }, msg: AppSchema.ChatMessage) {
+    async computePrompt({ active }, msg: AppSchema.ChatMessage, shown: boolean) {
       if (!active) return
 
       const { msgs } = msgStore.getState()
@@ -550,7 +550,7 @@ export const chatStore = createStore<ChatState>('chat', {
         encoder
       )
 
-      return { prompt }
+      return { prompt: { ...prompt, shown } }
     },
 
     closePrompt() {


### PR DESCRIPTION
New UI setting to show a dotted line under messages excluded from the context window

caveats:
- won't be displayed on chat load until a generation is first made for some reason
- not sure this is 100% accurate for all possible configurations, but tested on claude/turbo/horde default presets, seemed ok
- code is bad and needs review 

![1702219187](https://github.com/agnaistic/agnai/assets/137551361/60f890d6-6905-483b-96c3-8ed5e0f944d7)
![1702220387](https://github.com/agnaistic/agnai/assets/137551361/24f53ea9-2032-4db2-9665-d586d05ca7dc)
