### PR TITLE
feat: {{#lowpriority}}

### DIFF
--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -421,23 +421,17 @@ export async function buildPromptParts(
 
   if (opts.userEmbeds) {
     const embeds = opts.userEmbeds.map((line) => line.text)
-    const fit = await fillPromptWithLines(
-      encoder,
-      opts.settings?.memoryUserEmbedLimit || 500,
-      '',
-      embeds
-    )
+    const fit = (
+      await fillPromptWithLines(encoder, opts.settings?.memoryUserEmbedLimit || 500, '', embeds)
+    ).adding
     parts.userEmbeds = fit
   }
 
   if (opts.chatEmbeds) {
     const embeds = opts.chatEmbeds.map((line) => `${line.name}: ${line.text}`)
-    const fit = await fillPromptWithLines(
-      encoder,
-      opts.settings?.memoryChatEmbedLimit || 500,
-      '',
-      embeds
-    )
+    const fit = (
+      await fillPromptWithLines(encoder, opts.settings?.memoryChatEmbedLimit || 500, '', embeds)
+    ).adding
     parts.chatEmbeds = fit
   }
 
@@ -541,7 +535,7 @@ export async function getLinesForPrompt(
 
   const history = messages.slice().sort(sortMessagesDesc).map(formatMsg)
 
-  const lines = await fillPromptWithLines(encoder, maxContext, '', history)
+  const lines = (await fillPromptWithLines(encoder, maxContext, '', history)).adding
 
   if (opts.trimSentences) {
     return lines.map(trimSentence)
@@ -569,11 +563,16 @@ export async function fillPromptWithLines(
   tokenLimit: number,
   amble: string,
   lines: string[],
-  inserts: Map<number, string> = new Map()
-) {
+  inserts: Map<number, string> = new Map(),
+  lowpriority: { idToReplace: string; content: string }[] = []
+): Promise<{ adding: string[]; unusedTokens: number }> {
   const insertsCost = await encoder([...inserts.values()].join(' '))
   const tokenLimitMinusInserts = tokenLimit - insertsCost
-  let count = await encoder(amble)
+  const ambleWithoutLowPriorityPlaceholders = lowpriority.reduce(
+    (amble, { idToReplace }) => amble.replace(idToReplace, ''),
+    amble
+  )
+  let count = await encoder(ambleWithoutLowPriorityPlaceholders)
   const adding: string[] = []
 
   let linesAddedCount = 0
@@ -596,7 +595,9 @@ export async function fillPromptWithLines(
     adding.push(formatInsert(remainingInserts))
   }
 
-  return adding
+  const unusedTokens = tokenLimitMinusInserts - count
+
+  return { adding, unusedTokens }
 }
 
 export function insertsDeeperThanConvoHistory(

--- a/common/template-parser.ts
+++ b/common/template-parser.ts
@@ -12,12 +12,13 @@ const parser = peggy.generate(grammar.trim(), {
   },
 })
 
-type PNode = PlaceHolder | ConditionNode | IteratorNode | InsertNode | string
+type PNode = PlaceHolder | ConditionNode | IteratorNode | InsertNode | LowPriorityNode | string
 
 type PlaceHolder = { kind: 'placeholder'; value: Holder; values?: any; pipes?: string[] }
 type ConditionNode = { kind: 'if'; value: Holder; values?: any; children: PNode[] }
 type IteratorNode = { kind: 'each'; value: IterableHolder; children: CNode[] }
 type InsertNode = { kind: 'history-insert'; values: number; children: PNode[] }
+type LowPriorityNode = { kind: 'lowpriority'; children: PNode[] }
 
 type CNode =
   | Exclude<PNode, { kind: 'each' }>
@@ -94,6 +95,7 @@ export type TemplateOpts = {
    */
   repeatable?: boolean
   inserts?: Map<number, string>
+  lowpriority?: { idToReplace: string; content: string }[]
 }
 
 /**
@@ -121,6 +123,7 @@ export async function parseTemplate(
   const ast = parser.parse(template, {}) as PNode[]
   readInserts(template, opts, ast)
   let output = render(template, opts, ast)
+  let unusedTokens = 0
 
   if (opts.limit && opts.limit.output) {
     // const lastIndex = Object.keys(opts.limit.output).reduce((prev, curr) => {
@@ -133,16 +136,32 @@ export async function parseTemplate(
     // }
 
     for (const [id, lines] of Object.entries(opts.limit.output)) {
-      const trimmed = (
-        await fillPromptWithLines(
-          opts.limit.encoder,
-          opts.limit.context,
-          output,
-          lines,
-          opts.inserts
-        )
-      ).reverse()
+      const filled = await fillPromptWithLines(
+        opts.limit.encoder,
+        opts.limit.context,
+        output,
+        lines,
+        opts.inserts,
+        opts.lowpriority
+      )
+      unusedTokens = filled.unusedTokens
+      const trimmed = filled.adding.reverse()
       output = output.replace(id, trimmed.join('\n'))
+      const outputLen = await opts.limit!.encoder(output)
+    }
+
+    // Adding the low priority blocks if we still have the budget for them,
+    // now that we inserted the conversation history.
+    // We start from the bottom (somewhat arbitrary design choice),
+    // hence the reverse().
+    for (const { idToReplace, content } of (opts.lowpriority ?? []).reverse()) {
+      const contentLength = await opts.limit!.encoder(content)
+      if (contentLength > unusedTokens) {
+        output = output.replace(idToReplace, '')
+      } else {
+        output = output.replace(idToReplace, content)
+        unusedTokens -= contentLength
+      }
     }
   }
 
@@ -249,7 +268,32 @@ function renderNode(node: PNode, opts: TemplateOpts) {
 
     case 'if':
       return renderCondition(node, node.children, opts)
+
+    case 'lowpriority':
+      return renderLowPriority(node, opts)
   }
+}
+
+/**
+ * This only returns an UUID, but adds the string meant to replace the UUID to the
+ * opts object. The UUID is only replaced with the actual content (or object) after
+ * the prompt is built once, because low priority content is NOT added if the
+ * rest of the prompt takes up the token budget already.
+ * It's up to the rest of the prompt-building to remove the UUIDs when
+ * calculating their token budget.
+ * This somewhat  grungy string manipulation but unavoidable with the way prompt
+ * segments get turned into strings at the same time as their tokens are counted.
+ */
+function renderLowPriority(node: LowPriorityNode, opts: TemplateOpts) {
+  const output: string[] = []
+  for (const child of node.children) {
+    const result = renderNode(child, opts)
+    if (result) output.push(result)
+  }
+  opts.lowpriority = opts.lowpriority ?? []
+  const lowpriorityBlockId = '__' + v4() + '__'
+  opts.lowpriority.push({ idToReplace: lowpriorityBlockId, content: output.join('') })
+  return lowpriorityBlockId
 }
 
 function renderProp(node: CNode, opts: TemplateOpts, entity: unknown, i: number) {

--- a/srv/api/chat/message.ts
+++ b/srv/api/chat/message.ts
@@ -314,12 +314,12 @@ export const generateMessageV2 = handle(async (req, res) => {
   const actions: AppSchema.ChatAction[] = []
 
   if (chat.mode === 'adventure') {
-    const lines = await fillPromptWithLines(
+    const lines = (await fillPromptWithLines(
       getTokenCounter('main', undefined),
       2048,
       '',
       body.lines.concat(`${body.replyAs.name}: ${responseText}`)
-    )
+    )).adding
 
     const prompt = cyoaTemplate(
       body.settings.service,

--- a/web/shared/PromptEditor/index.tsx
+++ b/web/shared/PromptEditor/index.tsx
@@ -63,6 +63,8 @@ const v2placeholders = {
   random: { required: false, limit: Infinity, inserted: 'random: a,b,c' },
   'each message': { required: false, limit: 1, inserted: `#each msg}} {{/each` },
   'each bot': { required: false, limit: 1, inserted: `#each bot}} {{/each` },
+  insert: { required: false, limit: Infinity, inserted: `#insert 3}} {{/insert` },
+  lowpriority: { required: false, limit: Infinity, inserted: `#lowpriority}} {{/lowpriority` },
 } satisfies Record<string, Placeholder>
 
 const helpers: { [key in InterpAll]?: JSX.Element | string } = {
@@ -86,7 +88,7 @@ const helpers: { [key in InterpAll]?: JSX.Element | string } = {
     'Produces a random word from a comma-separated list. E.g.: `{{random happy, sad, jealous, angry}}`',
   'each bot': (
     <>
-      Suported properties: <code>{`{{.name}} {{.persona}}`}</code>
+      Supported properties: <code>{`{{.name}} {{.persona}}`}</code>
       <br />
       Example: <code>{`{{#each bot}}{{.name}}'s personality: {{.persona}}{{/each}}`}</code>
     </>
@@ -100,6 +102,22 @@ const helpers: { [key in InterpAll]?: JSX.Element | string } = {
       <br />
       Full example:{' '}
       <code>{`{{#each msg}}{{#if .isuser}}User: {{.msg}}{{/if}}{{#if .isbot}}Bot: {{.msg}}{{/if}}{{/each}}`}</code>
+    </>
+  ),
+  insert: (
+    <>
+      Similar to character note, inserted n messages from the bottom of the conversation history
+      <br />
+      Example: <code>{`{{#insert 3}}[Genre: Horror]{{/insert}}`}</code>
+    </>
+  ),
+  lowpriority: (
+    <>
+      Text that is only inserted if there still is token budget remaining for it after inserting
+      conversation history.
+      <br />
+      Example:{' '}
+      <code>{`{{#if example_dialogue}}{{#lowpriority}}This is how {{char}} speaks: {{example_dialogue}}{{/lowpriority}}{{/if}}`}</code>
     </>
   ),
 }


### PR DESCRIPTION
Adds a new {{#lowpriority}}{{/lowpriority}} syntax for text that is only inserted if there still is token budget remaining for it after inserting conversation history.

Suggested usage:
```
{{#if example_dialogue}}
{{#lowpriority}}
This is how {{char}} speaks:
{{example_dialogue}}
{{/lowpriority}}
{{/if}}
```

Added documentation for it in Placeholder Definitions, as well as documentation for {{#insert}}. This adds buttons for insert and lowpriority in the Prompt Template string builder.

NOT SUPPORTED ON CLAUDE/OPENAI CHAT.