### PR TITLE
Separate 2.1 and 2.0 Claude model entries

### DIFF
--- a/common/adapters.ts
+++ b/common/adapters.ts
@@ -152,6 +152,8 @@ export const OPENAI_CHAT_MODELS: Record<string, boolean> = {
 export const CLAUDE_MODELS = {
   ClaudeV1: 'claude-v1',
   ClaudeV2: 'claude-2',
+  ClaudeV2_0: 'claude-2.0',
+  ClaudeV2_1: 'claude-2.1',
   ClaudeV1_100k: 'claude-v1-100k',
   ClaudeV1_0: 'claude-v1.0',
   ClaudeV1_2: 'claude-v1.2',

--- a/web/shared/GenerationSettings.tsx
+++ b/web/shared/GenerationSettings.tsx
@@ -236,6 +236,30 @@ const GeneralSettings: Component<
     return base
   })
 
+  const CLAUDE_LABELS = {
+    ClaudeV2: 'Latest: Claude v2',
+    ClaudeV2_1: 'Claude v2.1',
+    ClaudeV2_0: 'Claude v2.0',
+    ClaudeV1_100k: 'Latest: Claude v1 100K',
+    ClaudeV1_3_100k: 'Claude v1.3 100K',
+    ClaudeV1: 'Latest: Claude v1',
+    ClaudeV1_3: 'Claude v1.3',
+    ClaudeV1_2: 'Claude v1.2',
+    ClaudeV1_0: 'Claude v1.0',
+    ClaudeInstantV1_100k: 'Latest: Claude Instant v1 100K',
+    ClaudeInstantV1_1_100k: 'Claude Instant v1.1 100K',
+    ClaudeInstantV1: 'Latest: Claude Instant v1',
+    ClaudeInstantV1_1: 'Claude Instant v1.1',
+    ClaudeInstantV1_0: 'Claude Instant v1.0',
+  } satisfies Record<keyof typeof CLAUDE_MODELS, string>
+
+  const claudeModels: () => Option<string>[] = createMemo(() => {
+    const models = new Map(Object.entries(CLAUDE_MODELS) as [keyof typeof CLAUDE_MODELS, string][])
+    const labels = Object.entries(CLAUDE_LABELS) as [keyof typeof CLAUDE_MODELS, string][]
+
+    return labels.map(([key, label]) => ({ label, value: models.get(key)! }))
+  })
+
   return (
     <div class="flex flex-col gap-2" classList={{ hidden: props.tab !== 'General' }}>
       <Show when={props.service === 'horde'}>
@@ -360,8 +384,8 @@ const GeneralSettings: Component<
         <Select
           fieldName="claudeModel"
           label="Claude Model"
-          items={modelsToItems(CLAUDE_MODELS)}
-          helperText="Which Claude model to use"
+          items={claudeModels()}
+          helperText="Which Claude model to use, models marked as 'Latest' will automatically switch when a new minor version is released."
           value={props.inherit?.claudeModel ?? defaultPresets.claude.claudeModel}
           disabled={props.disabled}
           service={props.service}


### PR DESCRIPTION
Added separate entries for Claude 2.0 and 2.1.

Also: added labels to the model select to clarify which entries will switch automatically when new models are added. 

![image](https://github.com/agnaistic/agnai/assets/148046683/fbc0bc1d-9b60-4160-ad31-4f4107fe3e04)

I don't have an Anthropic key, so unfortunately I can't test it.

Fixes #728 