### PR TITLE
Add new GPT 4.5 models

### DIFF
--- a/common/adapters.ts
+++ b/common/adapters.ts
@@ -127,6 +127,8 @@ export const OPENAI_MODELS = {
   GPT4_32k_0314: 'gpt-4-32k-0314',
   GPT4_32k_0613: 'gpt-4-32k-0613',
   GPT45_1106: 'gpt-4-1106-preview',
+  GPT45_0125: 'gpt-4-0125-preview',
+  GPT45_Preview: 'gpt-4-turbo-preview', // latest GPT 4 Turbo
 } as const
 
 export const OPENAI_CHAT_MODELS: Record<string, boolean> = {
@@ -142,6 +144,8 @@ export const OPENAI_CHAT_MODELS: Record<string, boolean> = {
   [OPENAI_MODELS.GPT4_32k_0314]: true,
   [OPENAI_MODELS.GPT4_32k_0613]: true,
   [OPENAI_MODELS.GPT45_1106]: true,
+  [OPENAI_MODELS.GPT45_0125]: true,
+  [OPENAI_MODELS.GPT45_Preview]: true,
 }
 
 /** Note: claude-v1 and claude-instant-v1 not included as they may point


### PR DESCRIPTION
`gpt-4-0125-preview` - new model
`gpt-4-turbo-preview` - Currently points to `gpt-4-0125-preview`.