### PR TITLE
Change Dockerfile to use non-slim bullseye version to prevent @parcel/watcher build fail.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.10.0-bullseye-slim
+FROM node:20.10.0-bullseye
 
 WORKDIR /app
 VOLUME [ "/app/db" ]


### PR DESCRIPTION
**Issue:**
When testing on an aarch64 system via Docker-Compose, the build fails with the following error:

```plaintext
22.03 Progress: resolved 1036, reused 0, downloaded 971, added 1032
23.05 Progress: resolved 1036, reused 0, downloaded 975, added 1036, done
23.50 .../node_modules/sharp install$ (node install/libvips && node install/dll-copy && prebuild-install) || (node install/can-compile && node-gyp rebuild && node install/dll-copy)
23.52 .../node_modules/protobufjs postinstall$ node scripts/postinstall
23.53 .../node_modules/@parcel/watcher install$ node-gyp-build
23.57 .../node_modules/protobufjs postinstall: Done
23.67 .../node_modules/sharp install: sharp: Downloading https://github.com/lovell/sharp-libvips/releases/download/v8.14.5/libvips-8.14.5-linux-arm64v8.tar.br
23.70 .../node_modules/@parcel/watcher install: gyp info it worked if it ends with ok
23.70 .../node_modules/@parcel/watcher install: gyp info using node-gyp@9.3.1
23.70 .../node_modules/@parcel/watcher install: gyp info using node@20.10.0 | linux | arm64
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python 
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python Python is not set from command line or npm configuration
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python Python is not set from environment variable PYTHON
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python checking if "python3" can be used
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python - "python3" is not in PATH or produced an error
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python checking if "python" can be used
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python - "python" is not in PATH or produced an error
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python 
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python **********************************************************
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python You need to install the latest version of Python.
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python Node-gyp should be able to find and use Python. If not,
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python you can try one of the following options:
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python - Use the switch --python="/path/to/pythonexecutable"
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python   (accepted by both node-gyp and npm)
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python - Set the environment variable PYTHON
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python - Set the npm configuration variable python:
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python   npm config set python "/path/to/pythonexecutable"
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python For more information consult the documentation at:
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python https://github.com/nodejs/node-gyp#installation
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python **********************************************************
23.75 .../node_modules/@parcel/watcher install: gyp ERR! find Python 
23.75 .../node_modules/@parcel/watcher install: gyp ERR! configure error 
23.75 .../node_modules/@parcel/watcher install: gyp ERR! stack Error: Could not find any Python installation to use
23.75 .../node_modules/@parcel/watcher install: gyp ERR! stack     at PythonFinder.fail (/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/lib/find-python.js:330:47)
23.75 .../node_modules/@parcel/watcher install: gyp ERR! stack     at PythonFinder.runChecks (/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/lib/find-python.js:159:21)
23.75 .../node_modules/@parcel/watcher install: gyp ERR! stack     at PythonFinder.<anonymous> (/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/lib/find-python.js:202:16)
23.75 .../node_modules/@parcel/watcher install: gyp ERR! stack     at PythonFinder.execFileCallback (/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/lib/find-python.js:294:16)
23.75 .../node_modules/@parcel/watcher install: gyp ERR! stack     at exithandler (node:child_process:430:5)
23.75 .../node_modules/@parcel/watcher install: gyp ERR! stack     at ChildProcess.errorhandler (node:child_process:442:5)
23.75 .../node_modules/@parcel/watcher install: gyp ERR! stack     at ChildProcess.emit (node:events:514:28)
23.75 .../node_modules/@parcel/watcher install: gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:292:12)
23.75 .../node_modules/@parcel/watcher install: gyp ERR! stack     at onErrorNT (node:internal/child_process:484:16)
23.75 .../node_modules/@parcel/watcher install: gyp ERR! stack     at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
23.75 .../node_modules/@parcel/watcher install: gyp ERR! System Linux 6.1.0-17-arm64
23.75 .../node_modules/@parcel/watcher install: gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/pnpm/dist/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
23.75 .../node_modules/@parcel/watcher install: gyp ERR! cwd /app/node_modules/.pnpm/registry.npmjs.org+@parcel+watcher@2.1.0/node_modules/@parcel/watcher
23.75 .../node_modules/@parcel/watcher install: gyp ERR! node -v v20.10.0
23.75 .../node_modules/@parcel/watcher install: gyp ERR! node-gyp -v v9.3.1
23.76 .../node_modules/@parcel/watcher install: gyp ERR! not ok 
23.76 .../node_modules/@parcel/watcher install: Failed
23.76  ELIFECYCLE  Command failed with exit code 1.
------
failed to solve: process "/bin/sh -c pnpm i --frozen-lockfile" did not complete successfully: exit code: 1
```

@parcel/watcher arm64 requires the python installation to finish the build, leading to an issue which is a bit like: https://github.com/parcel-bundler/parcel/issues/6880

Switching from the slim to the non-slim version of the Docker image, which contains python, resulted in a successful build.

An alternative, albeit less convenient, approach to maintain the "slim" version is to add the following lines to the Dockerfile:
`RUN apt update && apt install python3 make g++ -y`

I'm not aware of any consequences following this change; the build was successful on two separate aarch64 Debian-based systems.