### PR TITLE
fix(web): tag input uses AutoComplete component

### DIFF
--- a/web/pages/Character/CreateCharacterForm.tsx
+++ b/web/pages/Character/CreateCharacterForm.tsx
@@ -430,7 +430,7 @@ export const CreateCharacterForm: Component<{
                 <TagInput
                   availableTags={tagState.tags.map((t) => t.tag)}
                   value={editor.state.tags}
-                  fieldName="tags"
+                  fieldName="_tags"
                   label="Tags"
                   helperText="Used to help you organize and filter your characters."
                   onSelect={(tags) => editor.update({ tags })}

--- a/web/shared/AutoComplete.tsx
+++ b/web/shared/AutoComplete.tsx
@@ -1,14 +1,14 @@
 import { createSignal, onCleanup, onMount } from 'solid-js'
 import { Component, For } from 'solid-js'
 
-type Option = {
+export type AutoCompleteOption = {
   label: string
   value: string
 }
 
 export const AutoComplete: Component<{
-  options: Option[]
-  onSelect: (option: Option) => void
+  options: AutoCompleteOption[]
+  onSelect: (option: AutoCompleteOption) => void
   close: () => void
   dir: 'up' | 'down'
   /**

--- a/web/shared/AutoComplete.tsx
+++ b/web/shared/AutoComplete.tsx
@@ -1,4 +1,4 @@
-import { createSignal, onCleanup, onMount } from 'solid-js'
+import { createMemo, createSignal, onCleanup, onMount } from 'solid-js'
 import { Component, For } from 'solid-js'
 
 export type AutoCompleteOption = {
@@ -16,6 +16,7 @@ export const AutoComplete: Component<{
    * up: offset is bottom: {offset}px
    */
   offset?: number
+  limit?: number
 }> = (props) => {
   const [selected, setSelected] = createSignal(0)
 
@@ -67,6 +68,13 @@ export const AutoComplete: Component<{
     document.removeEventListener('keydown', listener)
   })
 
+  const options = createMemo(() => {
+    if (props.limit && props.limit > 0 && Number.isFinite(props.limit)) {
+      return props.options.slice(0, props.limit)
+    }
+    return props.options
+  })
+
   return (
     <ul
       class="bg-900 absolute left-0 flex max-h-40 w-56 flex-col gap-[2px] overflow-y-auto rounded-md border-[1px] border-[var(--bg-700)]"
@@ -75,7 +83,7 @@ export const AutoComplete: Component<{
         [props.dir === 'up' ? 'bottom' : 'top']: `${props.offset ?? 44}px`,
       }}
     >
-      <For each={props.options}>
+      <For each={options()}>
         {(opt, i) => (
           <li
             class="ellipsis cursor-pointer px-2 pb-2 pt-1 text-sm hover:bg-[var(--bg-700)]"

--- a/web/shared/TagInput.tsx
+++ b/web/shared/TagInput.tsx
@@ -1,5 +1,6 @@
-import { Component, For, JSX, createEffect, createSignal } from 'solid-js'
+import { Component, For, JSX, createEffect, createSignal, Show } from 'solid-js'
 import { FormLabel } from './FormLabel'
+import { AutoComplete, AutoCompleteOption } from '/web/shared/AutoComplete'
 
 interface TagInputProps {
   availableTags: string[]
@@ -18,7 +19,7 @@ interface TagInputProps {
 const TagInput: Component<TagInputProps> = (props) => {
   const [tags, setTags] = createSignal<string[]>([])
   const [inputValue, setInputValue] = createSignal<string>('')
-  const [suggestions, setSuggestions] = createSignal<string[]>([])
+  const [suggestions, setSuggestions] = createSignal<AutoCompleteOption[]>([])
 
   createEffect(() => {
     setTags(props.value || [])
@@ -26,11 +27,18 @@ const TagInput: Component<TagInputProps> = (props) => {
 
   function updateSuggestions(value: string) {
     setSuggestions(
-      props.availableTags.filter((tag) => tag.startsWith(value) && !tags().includes(tag))
+      props.availableTags
+        .filter((tag) => tag.startsWith(value) && !tags().includes(tag))
+        .map((tag) => ({ label: tag, value: tag }))
     )
   }
 
-  function addTag(tag: string) {
+  function resetSuggestions() {
+    setSuggestions([])
+  }
+
+  function addTag(tagOrOption: string | AutoCompleteOption) {
+    const tag = typeof tagOrOption === 'string' ? tagOrOption : tagOrOption.value
     const updatedTags = Array.from(new Set([...tags(), tag]))
 
     if (props.strict) {
@@ -40,7 +48,7 @@ const TagInput: Component<TagInputProps> = (props) => {
 
     setTags(updatedTags)
     setInputValue('')
-    setSuggestions([])
+    resetSuggestions()
     props.onSelect(updatedTags)
   }
 
@@ -60,10 +68,7 @@ const TagInput: Component<TagInputProps> = (props) => {
     const value = inputValue()
     if (e.key === 'Backspace' && value === '' && lastTag) {
       removeTag(lastTag)
-    } else if (e.key === 'Enter' && value !== '' && suggestions().length > 0) {
-      e.preventDefault()
-      addTag(suggestions()[0])
-    } else if ((e.key === ',' || e.key == 'Enter') && value !== '') {
+    } else if ((e.key === ',' || e.key == 'Enter') && value !== '' && suggestions().length === 0) {
       e.preventDefault()
       addTag(value)
     }
@@ -89,22 +94,23 @@ const TagInput: Component<TagInputProps> = (props) => {
           value={inputValue()}
           onInput={handleInputChange}
           onKeyDown={handleInputKeyDown}
+          onBlur={resetSuggestions}
           placeholder={tags().length || inputValue() ? '' : props.placeholder ?? 'Add tags...'}
           disabled={props.disabled}
+          autocomplete="off"
         />
       </div>
-      <ul class="absolute left-0 z-10 mt-1 bg-white text-gray-800 shadow-md">
-        <For each={suggestions()}>
-          {(suggestion) => (
-            <li
-              class="cursor-pointer px-2 py-1 hover:bg-gray-200"
-              onClick={() => addTag(suggestion)}
-            >
-              {suggestion}
-            </li>
-          )}
-        </For>
-      </ul>
+      <div class="relative">
+        <Show when={suggestions().length > 0}>
+          <AutoComplete
+            options={suggestions()}
+            onSelect={addTag}
+            close={resetSuggestions}
+            dir="down"
+            offset={0}
+          />
+        </Show>
+      </div>
     </div>
   )
 }

--- a/web/shared/TagInput.tsx
+++ b/web/shared/TagInput.tsx
@@ -68,7 +68,10 @@ const TagInput: Component<TagInputProps> = (props) => {
     const value = inputValue()
     if (e.key === 'Backspace' && value === '' && lastTag) {
       removeTag(lastTag)
-    } else if ((e.key === ',' || e.key == 'Enter') && value !== '' && suggestions().length === 0) {
+    } else if (e.key == 'Enter' && value !== '' && suggestions().length === 0) {
+      e.preventDefault()
+      addTag(value)
+    } else if (e.key === ',' && value !== '') {
       e.preventDefault()
       addTag(value)
     }

--- a/web/shared/TagInput.tsx
+++ b/web/shared/TagInput.tsx
@@ -55,6 +55,7 @@ const TagInput: Component<TagInputProps> = (props) => {
   function removeTag(tagToRemove: string) {
     const updatedTags = tags().filter((tag) => tag !== tagToRemove)
     setTags(updatedTags)
+    setInputValue('')
     props.onSelect(updatedTags)
   }
 
@@ -65,7 +66,7 @@ const TagInput: Component<TagInputProps> = (props) => {
 
   function handleInputKeyDown(e: KeyboardEvent) {
     const lastTag = tags()[tags().length - 1]
-    const value = inputValue()
+    const value = inputValue().trim()
     if (e.key === 'Backspace' && value === '' && lastTag) {
       removeTag(lastTag)
     } else if (e.key == 'Enter' && value !== '' && suggestions().length === 0) {
@@ -74,6 +75,17 @@ const TagInput: Component<TagInputProps> = (props) => {
     } else if (e.key === ',' && value !== '') {
       e.preventDefault()
       addTag(value)
+    }
+  }
+
+  function handleBlur(e: Event) {
+    resetSuggestions()
+    // do not leave trailing text in the input
+    const value = inputValue().trim()
+    if (value !== '' && value !== ',') {
+      addTag(value)
+    } else {
+      setInputValue('')
     }
   }
 
@@ -97,7 +109,7 @@ const TagInput: Component<TagInputProps> = (props) => {
           value={inputValue()}
           onInput={handleInputChange}
           onKeyDown={handleInputKeyDown}
-          onBlur={resetSuggestions}
+          onBlur={handleBlur}
           placeholder={tags().length || inputValue() ? '' : props.placeholder ?? 'Add tags...'}
           disabled={props.disabled}
           autocomplete="off"

--- a/web/shared/TagInput.tsx
+++ b/web/shared/TagInput.tsx
@@ -123,6 +123,7 @@ const TagInput: Component<TagInputProps> = (props) => {
             close={resetSuggestions}
             dir="down"
             offset={0}
+            limit={5}
           />
         </Show>
       </div>


### PR DESCRIPTION
Changes tag input to use autocomplete component instead of an in-place list for better ux at 0 maintenance cost since the component is already there.

Additionally, it addresses the bug where input tag in character forms would be overwritten by the raw `tags` value.

Closes: #805 