### PR TITLE
fix: correctly handle scenario events

### DIFF
--- a/common/scenario.ts
+++ b/common/scenario.ts
@@ -1,0 +1,24 @@
+import { AppSchema } from './types'
+
+const eventTypes: Record<AppSchema.ScenarioEventType, boolean> = {
+  character: true,
+  hidden: true,
+  ooc: true,
+  world: true,
+}
+
+export function isScenarioEvent(event?: any): event is AppSchema.ScenarioEventType {
+  if (typeof event !== 'string') return false
+  if (!event.startsWith('send-event:')) return false
+
+  const [, type] = event.split(':')
+  return !!eventTypes[type as AppSchema.ScenarioEventType]
+}
+
+export function getScenarioEventType(event: string): AppSchema.ScenarioEventType | undefined {
+  if (!event.startsWith('send-event')) return
+
+  const [, type] = event.split(':') as AppSchema.ScenarioEventType[]
+
+  return eventTypes[type] ? type : undefined
+}

--- a/common/types/schema.ts
+++ b/common/types/schema.ts
@@ -80,12 +80,14 @@ export namespace AppSchema {
 
     imagesEnabled: boolean
     imagesHost: string
-    imagesModels: Array<{
-      name: string
-      desc: string
-      init: { steps: number; cfg: number; height: number; width: number }
-      limit: { steps: number; cfg: number; height: number; width: number }
-    }>
+    imagesModels: ImageModel[]
+  }
+
+  export type ImageModel = {
+    name: string
+    desc: string
+    init: { steps: number; cfg: number; height: number; width: number }
+    limit: { steps: number; cfg: number; height: number; width: number }
   }
 
   export interface Announcement {
@@ -389,12 +391,12 @@ export namespace AppSchema {
     ooc?: boolean
     system?: boolean
     meta?: any
-    event?: EventTypes | undefined
+    event?: ScenarioEventType | undefined
     state?: string
     values?: Record<string, string | number | boolean>
   }
 
-  export type EventTypes = 'world' | 'character' | 'hidden' | 'ooc'
+  export type ScenarioEventType = 'world' | 'character' | 'hidden' | 'ooc'
 
   /** Description of the character or user */
   export type Persona =
@@ -664,7 +666,7 @@ export namespace AppSchema {
     name: string
     requires: string[]
     assigns: string[]
-    type: EventTypes
+    type: ScenarioEventType
     text: string
     trigger: T
   }

--- a/srv/adapter/type.ts
+++ b/srv/adapter/type.ts
@@ -10,6 +10,7 @@ export type GenerateRequestV2 = {
     | 'send-event:world'
     | 'send-event:character'
     | 'send-event:hidden'
+    | 'send-event:ooc'
     | 'ooc'
     | 'retry'
     | 'continue'

--- a/srv/api/chat/message.ts
+++ b/srv/api/chat/message.ts
@@ -12,7 +12,14 @@ import { publishMany } from '../ws/handle'
 type GenRequest = UnwrapBody<typeof genValidator>
 
 const sendValidator = {
-  kind: ['send-noreply', 'ooc', 'send-event:ooc'],
+  kind: [
+    'send-noreply',
+    'ooc',
+    'send-event:world',
+    'send-event:character',
+    'send-event:hidden',
+    'send-event:ooc',
+  ],
   text: 'string',
   impersonate: 'any?',
 } as const

--- a/srv/api/chat/message.ts
+++ b/srv/api/chat/message.ts
@@ -579,6 +579,9 @@ async function handleGuestGenerate(body: GenRequest, req: AppRequest, res: Respo
     case 'retry':
     case 'self':
     case 'send':
+    case 'send-event:world':
+    case 'send-event:character':
+    case 'send-event:hidden':
       sendGuest(guest, {
         type: 'guest-message-created',
         requestId,

--- a/srv/api/chat/message.ts
+++ b/srv/api/chat/message.ts
@@ -8,6 +8,7 @@ import { AppSchema } from '../../../common/types/schema'
 import { v4 } from 'uuid'
 import { Response } from 'express'
 import { publishMany } from '../ws/handle'
+import { getScenarioEventType } from '/common/scenario'
 
 type GenRequest = UnwrapBody<typeof genValidator>
 
@@ -91,9 +92,7 @@ export const createMessage = handle(async (req) => {
       userId: impersonate ? undefined : 'anon',
       characterId: impersonate?._id,
       ooc: body.kind === 'ooc' || body.kind === 'send-event:ooc',
-      event: body.kind.startsWith('send-event')
-        ? (body.kind.split(':')[1] as AppSchema.EventTypes)
-        : undefined,
+      event: getScenarioEventType(body.kind),
     })
     sendGuest(guest, { type: 'message-created', msg: newMsg, chatId })
   } else {
@@ -109,9 +108,7 @@ export const createMessage = handle(async (req) => {
       characterId: impersonate?._id,
       senderId: userId,
       ooc: body.kind === 'ooc' || body.kind === 'send-event:ooc',
-      event: body.kind.startsWith('send-event')
-        ? (body.kind.split(':')[1] as AppSchema.EventTypes)
-        : undefined,
+      event: getScenarioEventType(body.kind),
     })
 
     sendMany(members, { type: 'message-created', msg: userMsg, chatId })
@@ -197,7 +194,7 @@ export const generateMessageV2 = handle(async (req, res) => {
       characterId: replyAs?._id,
       senderId: undefined,
       ooc: false,
-      event: body.kind.split(':')[1] as AppSchema.EventTypes,
+      event: getScenarioEventType(body.kind),
     })
     sendMany(members, { type: 'message-created', msg: userMsg, chatId })
   }
@@ -487,7 +484,7 @@ async function handleGuestGenerate(body: GenRequest, req: AppRequest, res: Respo
     newMsg = newMessage(v4(), chatId, body.text!, {
       characterId: replyAs?._id,
       ooc: false,
-      event: body.kind.split(':')[1] as AppSchema.EventTypes,
+      event: getScenarioEventType(body.kind),
     })
   }
 
@@ -612,7 +609,7 @@ function newMessage(
     characterId?: string
     ooc: boolean
     meta?: any
-    event: undefined | AppSchema.EventTypes
+    event: undefined | AppSchema.ScenarioEventType
     retries?: string[]
   }
 ) {

--- a/srv/db/messages.ts
+++ b/srv/db/messages.ts
@@ -23,7 +23,7 @@ export type NewMessage = {
   imagePrompt?: string
   actions?: AppSchema.ChatMessage['actions']
   meta?: any
-  event: AppSchema.EventTypes | undefined
+  event: AppSchema.ScenarioEventType | undefined
   retries?: string[]
 }
 

--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -238,6 +238,12 @@ const ChatDetail: Component = () => {
     }
   })
 
+  // force replyAs to be set when there is only one bot
+  createEffect(() => {
+    if (ctx.activeBots.length !== 1 || chats.replyAs) return
+    chatStore.setAutoReplyAs(ctx.activeBots[0]._id)
+  })
+
   const sendMessage = (message: string, ooc: boolean, onSuccess?: () => void) => {
     if (isDevCommand(message)) {
       switch (message) {

--- a/web/pages/Chat/components/InputBar.tsx
+++ b/web/pages/Chat/components/InputBar.tsx
@@ -178,7 +178,10 @@ const InputBar: Component<{
   }
 
   const triggerEvent = () => {
-    eventStore.triggerEvent(props.chat, props.botMap[chats.replyAs!])
+    const char =
+      chats.replyAs && chats.replyAs in props.botMap ? props.botMap[chats.replyAs] : undefined
+
+    eventStore.triggerEvent(props.chat, char)
     setMenu(false)
   }
 
@@ -327,13 +330,7 @@ const InputBar: Component<{
                 <Megaphone size={18} /> Play Voice
               </Button>
             </Show>
-            <Show
-              when={
-                !!ctx.chat?.scenarioIds?.length &&
-                isOwner() &&
-                (chats.replyAs || ctx.activeBots.length === 1)
-              }
-            >
+            <Show when={!!ctx.chat?.scenarioIds?.length && isOwner()}>
               <Button schema="secondary" class="w-full" onClick={triggerEvent} alignLeft>
                 <Zap /> Trigger Event
               </Button>

--- a/web/pages/Chat/components/Message.tsx
+++ b/web/pages/Chat/components/Message.tsx
@@ -169,7 +169,7 @@ const Message: Component<MessageProps> = (props) => {
               data-user-avatar={isUser}
             >
               <Switch>
-                <Match when={props.msg.event === 'world'}>
+                <Match when={props.msg.event === 'world' || props.msg.event === 'ooc'}>
                   <div
                     class={`avatar-${format().size} flex shrink-0 items-center justify-center pt-3`}
                   >

--- a/web/pages/Scenario/EditScenarioEvents.tsx
+++ b/web/pages/Scenario/EditScenarioEvents.tsx
@@ -25,7 +25,7 @@ import PromptEditor from '/web/shared/PromptEditor'
 import { FormLabel } from '/web/shared/FormLabel'
 import { Card, Pill, TitleCard } from '/web/shared/Card'
 
-const eventTypeOptions: Option<AppSchema.EventTypes>[] = [
+const eventTypeOptions: Option<AppSchema.ScenarioEventType>[] = [
   { value: 'hidden', label: 'Hidden (not shown to the user)' },
   { value: 'world', label: 'World (shown, external to the character)' },
   { value: 'character', label: 'Character (shown, thought or action by the character)' },

--- a/web/store/data/messages.ts
+++ b/web/store/data/messages.ts
@@ -170,15 +170,25 @@ export async function getMessages(chatId: string, before: string) {
   return res
 }
 
+type EventKind =
+  | 'send-event:world'
+  | 'send-event:character'
+  | 'send-event:hidden'
+  | 'send-event:ooc'
+
+function isEventOpts(opts: GenerateOpts): opts is { kind: EventKind; text: string } {
+  return (
+    opts.kind.startsWith('send-event:') &&
+    ['world', 'character', 'hidden', 'ooc'].includes(opts.kind.split(':')[1])
+  )
+}
+
 export type GenerateOpts =
   /**
    * A user sending a new message
    */
   | { kind: 'send'; text: string }
-  | { kind: 'send-event:world'; text: string }
-  | { kind: 'send-event:character'; text: string }
-  | { kind: 'send-event:hidden'; text: string }
-  | { kind: 'send-event:ooc'; text: string }
+  | { kind: EventKind; text: string }
   | { kind: 'send-noreply'; text: string }
   | { kind: 'ooc'; text: string }
   /**
@@ -208,7 +218,13 @@ export async function generateResponse(opts: GenerateOpts) {
     return localApi.error('No active chat. Try refreshing.')
   }
 
-  if (opts.kind === 'ooc' || opts.kind === 'send-noreply' || opts.kind === 'send-event:ooc') {
+  if (
+    opts.kind === 'ooc' ||
+    opts.kind === 'send-noreply' ||
+    opts.kind === 'send-event:ooc' ||
+    // allow events to be sent without a reply in multi-bot chats
+    (isEventOpts(opts) && !active.replyAs)
+  ) {
     return createMessage(active.chat._id, opts)
   }
 
@@ -332,7 +348,7 @@ async function getActivePromptOptions(
 }
 
 async function createActiveChatPrompt(
-  opts: Exclude<GenerateOpts, { kind: 'ooc' | 'send-noreply' }>
+  opts: Exclude<GenerateOpts, { kind: 'ooc' | 'send-noreply' | 'send-event:ooc' }>
 ) {
   const { active } = chatStore.getState()
   const { ui } = userStore.getState()
@@ -598,7 +614,7 @@ async function getGenerateProps(
  */
 async function createMessage(
   chatId: string,
-  opts: { kind: 'ooc' | 'send-noreply' | 'send-event:ooc'; text: string }
+  opts: { kind: 'ooc' | 'send-noreply' | EventKind; text: string }
 ) {
   const { impersonating } = getStore('character').getState()
   const impersonate = opts.kind === 'send-noreply' ? impersonating : undefined

--- a/web/store/data/messages.ts
+++ b/web/store/data/messages.ts
@@ -178,6 +178,7 @@ export type GenerateOpts =
   | { kind: 'send-event:world'; text: string }
   | { kind: 'send-event:character'; text: string }
   | { kind: 'send-event:hidden'; text: string }
+  | { kind: 'send-event:ooc'; text: string }
   | { kind: 'send-noreply'; text: string }
   | { kind: 'ooc'; text: string }
   /**
@@ -207,7 +208,7 @@ export async function generateResponse(opts: GenerateOpts) {
     return localApi.error('No active chat. Try refreshing.')
   }
 
-  if (opts.kind === 'ooc' || opts.kind === 'send-noreply') {
+  if (opts.kind === 'ooc' || opts.kind === 'send-noreply' || opts.kind === 'send-event:ooc') {
     return createMessage(active.chat._id, opts)
   }
 
@@ -595,7 +596,10 @@ async function getGenerateProps(
 /**
  * Create a user message that does not generate a bot response
  */
-async function createMessage(chatId: string, opts: { kind: 'ooc' | 'send-noreply'; text: string }) {
+async function createMessage(
+  chatId: string,
+  opts: { kind: 'ooc' | 'send-noreply' | 'send-event:ooc'; text: string }
+) {
   const { impersonating } = getStore('character').getState()
   const impersonate = opts.kind === 'send-noreply' ? impersonating : undefined
   return api.post<{ requestId: string }>(`/chat/${chatId}/send`, {

--- a/web/store/event.ts
+++ b/web/store/event.ts
@@ -214,11 +214,7 @@ export function selectOnCharacterMessageReceivedEvent(
 
 function executeEvent(chat: AppSchema.Chat, event: AppSchema.ScenarioEvent) {
   updateChatScenarioStates(chat, event.assigns)
-  if (event.type === 'ooc') {
-    msgStore.queue(chat._id, `**Scenario Message**\n` + event.text, 'ooc')
-  } else {
-    msgStore.queue(chat._id, event.text, `send-event:${event.type}`)
-  }
+  msgStore.queue(chat._id, event.text, `send-event:${event.type}`)
 }
 
 function updateChatScenarioStates(chat: AppSchema.Chat, assigns: string[]) {

--- a/web/store/event.ts
+++ b/web/store/event.ts
@@ -85,7 +85,7 @@ export const eventStore = createStore<ChatEventState>('events', { events: [], pr
           if (event) executeEvent(chat, event)
         }
       },
-      async triggerEvent(_, chat: AppSchema.Chat, char: AppSchema.Character) {
+      async triggerEvent(_, chat: AppSchema.Chat, char?: AppSchema.Character) {
         const scenarios = scenarioStore
           .getState()
           .scenarios.filter((s) => chat.scenarioIds?.includes(s._id))
@@ -108,9 +108,11 @@ export const eventStore = createStore<ChatEventState>('events', { events: [], pr
         }
 
         const profile = userStore.getState().profile
-        const prompt = selected.event.text
-          .replace(BOT_REPLACE, char.name)
-          .replace(SELF_REPLACE, profile?.handle || 'You')
+
+        let prompt = selected.event.text.replace(SELF_REPLACE, profile?.handle || 'You')
+        if (char) {
+          prompt = prompt.replace(BOT_REPLACE, char.name)
+        }
 
         const eventState = {
           charId: chat.characterId,

--- a/web/store/event.ts
+++ b/web/store/event.ts
@@ -12,7 +12,7 @@ export type ChatEvent = {
   charId: string
   chatId: string
   prompt: string
-  event: AppSchema.EventTypes
+  event: AppSchema.ScenarioEventType
 }
 
 type ChatEventState = {

--- a/web/store/message.ts
+++ b/web/store/message.ts
@@ -33,6 +33,7 @@ type SendModes =
   | 'send-event:world'
   | 'send-event:character'
   | 'send-event:hidden'
+  | 'send-event:ooc'
   | 'retry'
   | 'self'
   | 'send-noreply'
@@ -403,6 +404,7 @@ export const msgStore = createStore<MsgState>(
 
         case 'ooc':
         case 'send-noreply':
+        case 'send-event:ooc':
           res = await msgsApi.generateResponse({ kind: mode, text: message })
           yield { partial: undefined, waiting: undefined }
           break

--- a/web/store/message.ts
+++ b/web/store/message.ts
@@ -396,17 +396,16 @@ export const msgStore = createStore<MsgState>(
           break
 
         case 'send':
+        case 'ooc':
         case 'send-event:world':
         case 'send-event:character':
         case 'send-event:hidden':
-          res = await msgsApi.generateResponse({ kind: mode, text: message })
-          break
-
-        case 'ooc':
         case 'send-noreply':
         case 'send-event:ooc':
           res = await msgsApi.generateResponse({ kind: mode, text: message })
-          yield { partial: undefined, waiting: undefined }
+          if ('result' in res && !res.result.generating) {
+            yield { partial: undefined, waiting: undefined }
+          }
           break
 
         default:


### PR DESCRIPTION
**UPDATE**: This PR's scope has been expanded to address a couple more issues that I discovered while working on the events code.

## OOC events support
Supports handling of OOC scenario events regardless of whether they were triggered automatically or manually.

Currently OOC events can only be triggered programmatically (e.g. on a "message received" trigger) and outputs the content as if it came from the user:
<details>
<summary>screenshot</summary>

![image](https://github.com/agnaistic/agnai/assets/4258136/a4620b38-4967-49b7-937c-ae543f070523)

</details>

This PR aims to provide a fix for a manual triggering of OOC events while making its interface closer align with the rest of the messages:
<details>
<summary>screenshot</summary>

![image](https://github.com/agnaistic/agnai/assets/4258136/146ff5af-bc2b-458b-bb18-942e332e712c)

</details>

**QA Instructions**:
1. Create a scenario that has 2 OOC events, one with "manual" trigger, one with "message received". The order in which they are triggered shouldn't matter
2. Triggering a manual event should output an OOC message like on the screenshot above.
3. Interact with the bot.
4. Check the prompt: the message in OOC event should not be included in the prompt
5. Once automatic event is triggered, repeat steps 3-4

## Guest mode scenarios
A small fix to handle the display of bot responses to event messages in guest mode.

**QA Instructions**:
1. Use guest mode
2. Create a chat with a scenario that has events
3. Make sure auto reply is on or it is a single bot chat
4. Triggering an event should provoke a response from bot

## Events in multi bot chats
Adds support for events in multi bot chats when auto reply is set to None. It is now correctly handles it by displaying an event message but not triggering a response.

**QA Instructions**:
1. Create a multi chat with a scenario that has events
2. Set auto-reply to None
3. Trigger an event
4. Event message should be displayed
5. Set auto-reply to a bot
6. Trigger an event
7. Event message should be displayed followed by a response from a chosen bot
8. Set auto-reply to None
9. Remove all the bots but one thus switching to a single bot chat
10. Send a message / trigger an event
11. The only bot that's left should correctly respond to the message

**Related**:
Closes: #812 
Closes: #835 
Closes: #846 
Closes: #847 

