### PR TITLE
Minor fixes for Claude 3

### DIFF
--- a/srv/adapter/chat-completion.ts
+++ b/srv/adapter/chat-completion.ts
@@ -181,7 +181,8 @@ export async function toChatCompletionPayload(
   opts: AdapterProps,
   maxTokens: number
 ): Promise<CompletionItem[]> {
-  const SYSTEM_ROLE = opts.gen.service === 'claude' ? 'user' : 'system'
+  const isClaude = opts.gen.service === 'claude' || opts.gen.thirdPartyFormat === 'claude'
+  const SYSTEM_ROLE = isClaude ? 'user' : 'system'
   if (opts.kind === 'plain') {
     return [{ role: SYSTEM_ROLE, content: opts.prompt }]
   }

--- a/srv/adapter/claude.ts
+++ b/srv/adapter/claude.ts
@@ -25,7 +25,8 @@ const TEXT_URL = `https://api.anthropic.com/v1/complete`
 const apiVersion = '2023-06-01' // https://docs.anthropic.com/claude/reference/versioning
 
 type ClaudeCompletion = {
-  completion: string
+  completion?: string
+  content?: { type: string; text?: string }[]
   delta?: { text: string }
   text?: string
   stop_reason: string | null
@@ -150,7 +151,7 @@ export const handleClaude: ModelAdapter = async function* (opts) {
   }
 
   try {
-    const completion = resp?.completion || ''
+    const completion = resp?.completion || resp?.content?.[0]?.text || ''
     if (!completion) {
       log.error({ body: resp }, 'Claude request failed: Empty response')
       yield { error: `Claude request failed: Received empty response. Try again.` }


### PR DESCRIPTION
Addresses the following two issues with Claude 3 support:
- When using a preset with a third-party API URL, `toChatCompletionPayload` was incorrectly treating the incoming prompt as an OpenAI-style chat completion and was inserting messages with `role: 'system'` which is not valid for Claude's chat completion API.
  - This is because when using the third party URL option with Claude prompt reformatting, `GenSettings.service` is `"kobold"`. We want to check `GenSettings.thirdPartyFormat` as that tells us that the chat completion prompt should use `"claude"` format.
- When streaming is disabled, all generations result in an empty response.
  - The streaming generator was updated for Claude 3, but the non-streaming path was still checking for `resp.completion`. It has been updated to check the first element of `response.content` instead, which is how the new Claude chat completions API returns a chat completion response.