### PR TITLE
Updated Claude chat models adapter to include the prefill and use the global system prompt field

### DIFF
--- a/srv/adapter/chat-completion.ts
+++ b/srv/adapter/chat-completion.ts
@@ -217,7 +217,7 @@ export async function toChatCompletionPayload(
   }
 
   // Append 'postamble' and system prompt (ujb)
-  const posts = await getPostInstruction(opts, messages) ?? []
+  const posts = (await getPostInstruction(opts, messages)) ?? []
   posts.reverse()
   for (const post of posts) {
     const encode = encoder()
@@ -268,14 +268,12 @@ export async function toChatCompletionPayload(
       addRemainingInserts()
       addedAllInserts = true
 
-      const { additions, consumed } = await splitSampleChat(
-        {
-          budget: maxBudget - tokens,
-          sampleChat: obj.content,
-          char: replyAs.name,
-          sender: handle,
-        },
-      )
+      const { additions, consumed } = await splitSampleChat({
+        budget: maxBudget - tokens,
+        sampleChat: obj.content,
+        char: replyAs.name,
+        sender: handle,
+      })
 
       if (tokens + consumed > maxBudget) {
         --i
@@ -361,7 +359,7 @@ export async function splitSampleChat(opts: SplitSampleChatProps) {
 
 async function getPostInstruction(
   opts: AdapterProps,
-  messages: CompletionItem[],
+  messages: CompletionItem[]
 ): Promise<CompletionItem[] | undefined> {
   let prefix = opts.parts.ujb ?? ''
 
@@ -383,9 +381,7 @@ async function getPostInstruction(
     }
 
     case 'continue':
-      return [
-        { role: 'system', content: `${prefix}\n\nContinue ${opts.replyAs.name}'s response` },
-      ]
+      return [{ role: 'system', content: `${prefix}\n\nContinue ${opts.replyAs.name}'s response` }]
 
     case 'summary': {
       let content = opts.user.images?.summaryPrompt || IMAGE_SUMMARY_PROMPT.openai
@@ -401,9 +397,7 @@ async function getPostInstruction(
       if (looks) {
         messages[0].content += '\n' + looks
       }
-      return [
-        { role: 'user', content },
-      ]
+      return [{ role: 'user', content }]
     }
 
     case 'self':
@@ -426,9 +420,9 @@ async function getPostInstruction(
         {
           role: 'assistant',
           content: `${opts.gen.prefill ?? ''}\n\n${appendName ? opts.replyAs.name : ''}:`.trim(),
-        } 
+        },
       ]
-      return messages.filter((m) => m.content); // Non-empty messages
+      return messages.filter((m) => m.content) // Non-empty messages
     }
   }
 }

--- a/tests/chat-model-sample-chat.spec.ts
+++ b/tests/chat-model-sample-chat.spec.ts
@@ -90,15 +90,12 @@ describe('Chat Completion Example Dialogue::', () => {
 })
 
 async function testInput(input: string, budget?: number) {
-  const result = await splitSampleChat(
-    {
-      sampleChat: input,
-      char: TEST_CHARACTER_NAME,
-      sender: TEST_USER_NAME,
-      budget,
-    },
-    'system'
-  )
+  const result = await splitSampleChat({
+    sampleChat: input,
+    char: TEST_CHARACTER_NAME,
+    sender: TEST_USER_NAME,
+    budget,
+  })
 
   return JSON.stringify(result.additions, null, 2)
 }


### PR DESCRIPTION
Prefill (resolves #870):
- I updated the chat-completions logic used for Claude and OpenAI to include `opts.gen.prefill` if it exists.
- Previously the `{{char}}:` part of the prompt was being sent as a system/user message, instead of as an assistant message (which is allowed per https://docs.anthropic.com/claude/reference/migrating-from-text-completions-to-messages#putting-words-in-claudes-mouth).
- Note that this affects the behavior with OpenAI models, but I think it's correct; I tested it with GPT-4 and it seemed to work fine.

System prompt:
- Claude has a single global system prompt field instead of allowing a 'system' role (https://docs.anthropic.com/claude/docs/system-prompts#how-to-use-system-prompts).
- I added logic in `claude.ts` to pull prefix out of the messages and put it in the `system` field. Other system messages get converted to user messages as before, but I moved that logic into the Claude adapter and got rid of the `SYSTEM_ROLE` variables.
- I initially tried to drop the first message, but Claude doesn't allow the assistant to start. The first message has to be from the user, and it cannot be empty, so hopefully using '...' doesn't affect much.

Let me know if you have any concerns, I'm happy to integrate feedback.