### PR TITLE
fix: trim incomplete sentences

### DIFF
--- a/common/util.ts
+++ b/common/util.ts
@@ -131,12 +131,13 @@ export function neat(params: TemplateStringsArray, ...rest: string[]) {
     .trim()
 }
 
-const endSymbols = new Set(`."”;’'*!！?？)}]\``.split(''))
-const allowedInMiddle = new Set(`.)}’'!?\``.split(''))
+const END_SYMBOLS = new Set(`."”;’'*!！?？)}]\``.split(''))
+const MID_SYMBOLS = new Set(`.)}’'!?\``.split(''))
+
 export function trimSentence(text: string) {
   let index = -1
   for (let i = text.length - 1; i >= 0; i--) {
-    if (endSymbols.has(text[i])) {
+    if (END_SYMBOLS.has(text[i])) {
       // Save if the punctuation mark is preceded by white space
       if (i && /[\p{White_Space}\n]/u.test(text[i - 1])) {
         index = i - 1
@@ -145,7 +146,7 @@ export function trimSentence(text: string) {
 
       // Skip if the punctuation mark is in the middle of a word
       if (
-        allowedInMiddle.has(text[i]) &&
+        MID_SYMBOLS.has(text[i]) &&
         i > 0 &&
         i < text.length - 1 &&
         /\p{L}/u.test(text[i - 1]) &&

--- a/tests/trim-sentence.spec.ts
+++ b/tests/trim-sentence.spec.ts
@@ -1,0 +1,66 @@
+import { trimSentence } from '../common/util'
+import { expect } from 'chai'
+
+describe('trimSentence', () => {
+  it('should trim a sentence correctly when the sentence ends with a punctuation mark', () => {
+    const text = 'Hello, world!'
+    const result = trimSentence(text)
+    expect(result).to.eq('Hello, world!')
+  })
+
+  it('should ignore a single orphan sentence', () => {
+    const text = 'Hello, world this is a test'
+    const result = trimSentence(text)
+    expect(result).to.eq('Hello, world this is a test')
+  })
+
+  it('should trim a sentence correctly when the sentence contains non-Latin characters', () => {
+    const text = 'こんにちは、世界！これはテストです'
+    const result = trimSentence(text)
+    expect(result).to.eq('こんにちは、世界！')
+  })
+
+  it('should trim a sentence correctly when the sentence contains a colon', () => {
+    const text = 'Hello, world: this is a test'
+    const result = trimSentence(text)
+    expect(result).to.eq('Hello, world: this is a test')
+  })
+
+  it('should trim a sentence to new line ignoring orphaned punctuation', () => {
+    const text = `*Hello world.*
+*`
+    const result = trimSentence(text)
+    expect(result).to.eq('*Hello world.*')
+  })
+
+  it ('should trim a sentence to new line ignoring any number of orphans', () => {
+    const text = `*Hello world.*
+    * ! `
+    const result = trimSentence(text)
+    expect(result).to.eq('*Hello world.*')
+  })
+
+  it('should ignore possessive apostrophes', () => {
+    const text = `Hello world. World's best`
+    const result = trimSentence(text)
+    expect(result).to.eq(`Hello world.`)
+  })
+
+  it('should ignore allowed punctuation inside words themselves', () => {
+    const text = `Hello world. Washington D.C is the capital of the United States`
+    const result = trimSentence(text)
+    expect(result).to.eq(`Hello world.`)
+  })
+
+  it('should trim orphaned punctuation at the end of a sentence', () => {
+    const text = `Hello World?" *`
+    const result = trimSentence(text)
+    expect(result).to.eq(`Hello World?"`)
+  })
+
+  it('should trim orphaned punctuation at the end of a sentence along with incomplete sentence', () => {
+    const text = `Hello World?" * Hello`
+    const result = trimSentence(text)
+    expect(result).to.eq(`Hello World?"`)
+  })
+})

--- a/web/pages/Settings/Agnaistic.tsx
+++ b/web/pages/Settings/Agnaistic.tsx
@@ -3,6 +3,7 @@ import { AIAdapter } from '/common/adapters'
 import { settingStore, userStore } from '/web/store'
 import Select from '/web/shared/Select'
 import { AppSchema } from '/common/types'
+import { getUserSubscriptionTier } from '/common/util'
 
 export const AgnaisticSettings: Component<{
   service: AIAdapter
@@ -13,7 +14,8 @@ export const AgnaisticSettings: Component<{
   const config = settingStore((s) => s.config)
 
   const opts = createMemo(() => {
-    const tierLevel = state.sub?.level ?? -1
+    const tier = state.user ? getUserSubscriptionTier(state.user!, state.tiers) : undefined
+    const tierLevel = tier?.level ?? -1
     const level = state.user?.admin ? Infinity : tierLevel
 
     return config.subs


### PR DESCRIPTION
Better handling of trimming incomplete sentences, mainly orphaned punctuation on new lines, repeating orphaned punctuation and edge cases involving punctuation in the middle of words (e.g. it won't leave words with possessive apostrophes anymore).

Closes: #824  