### PR TITLE
feat: editable embeds

### DIFF
--- a/web/pages/Chat/components/MemoryModal.tsx
+++ b/web/pages/Chat/components/MemoryModal.tsx
@@ -1,4 +1,4 @@
-import { Save } from 'lucide-solid'
+import { Edit, Save } from 'lucide-solid'
 import { Component, createEffect, createMemo, createSignal, JSX, onMount, Show } from 'solid-js'
 import { AppSchema } from '../../../../common/types/schema'
 import Button from '../../../shared/Button'
@@ -8,6 +8,8 @@ import { chatStore } from '../../../store'
 import { memoryStore } from '../../../store'
 import EditMemoryForm, { EntrySort } from '../../Memory/EditMemory'
 import EmbedContent from '../../Memory/EmbedContent'
+import { EditEmbedModal } from '/web/shared/EditEmbedModal'
+import { Portal } from 'solid-js/web'
 
 const ChatMemoryModal: Component<{
   chat: AppSchema.Chat | undefined
@@ -22,6 +24,7 @@ const ChatMemoryModal: Component<{
 
   const [id, setId] = createSignal('')
   const [embedId, setEmbedId] = createSignal(props.chat?.userEmbedId)
+  const [editingEmbed, setEditingEmbed] = createSignal<boolean>(false)
   const [book, setBook] = createSignal<AppSchema.MemoryBook>()
   const [entrySort, setEntrySort] = createSignal<EntrySort>('creationDate')
   const updateEntrySort = (item: Option<string>) => {
@@ -136,14 +139,35 @@ const ChatMemoryModal: Component<{
             onChange={(item) => setEmbedId(item.value)}
             value={embedId()}
           />
-          <Button
-            class="w-fit"
-            disabled={embedId() === props.chat?.userEmbedId}
-            onClick={useUserEmbed}
-          >
-            <Save />
-            Use Embedding
-          </Button>
+          <div class="flex items-center gap-1">
+            <Button
+              class="w-fit"
+              disabled={embedId() === props.chat?.userEmbedId}
+              onClick={useUserEmbed}
+            >
+              <Save />
+              Use Embedding
+            </Button>
+
+            <Show when={embedId() === props.chat?.userEmbedId}>
+              <Button
+                class="w-fit"
+                schema="secondary"
+                disabled={editingEmbed() || !props.chat?.userEmbedId}
+                onClick={() => setEditingEmbed(true)}
+              >
+                <Edit />
+                Edit
+              </Button>
+            </Show>
+          </div>
+          <Portal>
+            <EditEmbedModal
+              show={editingEmbed()}
+              embedId={embedId()}
+              close={() => setEditingEmbed(false)}
+            />
+          </Portal>
           <Divider />
         </Show>
         <EmbedContent />

--- a/web/pages/Memory/Memory.tsx
+++ b/web/pages/Memory/Memory.tsx
@@ -21,22 +21,22 @@ export const EmbedsTab: Component = (props) => {
       <PageHeader title="Memory - Embeddings" />
       <EmbedContent />
 
-      <div class="my-2 flex flex-col gap-2">
+      <div class="flex flex-col gap-2">
         <For each={state.embeds}>
           {(each) => (
-            <SolidCard
-              border
-              size="sm"
-              class="flex items-center justify-between overflow-hidden"
-              bg="bg-700"
-            >
-              <div class="ellipsis">{each.id}</div>
-              <div>
-                <Button schema="red" onClick={() => setDeleting(each.id)}>
-                  <Trash size={14} />
-                </Button>
+            <div class="mt-2 flex w-full items-center gap-4">
+              <SolidCard
+                size="md"
+                class="flex w-full items-center justify-between overflow-hidden"
+                bg="bg-800"
+              >
+                <div class="ellipsis font-bold">{each.id}</div>
+              </SolidCard>
+
+              <div class="icon-button" onClick={() => setDeleting(each.id)}>
+                <Trash />
               </div>
-            </SolidCard>
+            </div>
           )}
         </For>
       </div>

--- a/web/pages/Memory/Memory.tsx
+++ b/web/pages/Memory/Memory.tsx
@@ -11,9 +11,7 @@ import { memoryStore, toastStore } from '../../store'
 import { SolidCard } from '/web/shared/Card'
 import EmbedContent from './EmbedContent'
 import { embedApi } from '/web/store/embeddings'
-import TextInput from '/web/shared/TextInput'
-import { RequestDocEmbed } from '/web/store/embeddings/types'
-import { getStrictForm } from '/web/shared/util'
+import { EditEmbedModal } from '/web/shared/EditEmbedModal'
 
 export const EmbedsTab: Component = (props) => {
   const state = memoryStore()
@@ -58,87 +56,6 @@ export const EmbedsTab: Component = (props) => {
         message={`Are you sure you wish to delete this embedding?\n\n${deleting()}`}
       />
     </>
-  )
-}
-
-const EditEmbedModal: Component<{ show: boolean; embedId?: string; close: () => void }> = (
-  props
-) => {
-  let form: HTMLFormElement | undefined
-
-  const [content, setContent] = createSignal<string>()
-  const [loading, setLoading] = createSignal(false)
-
-  createEffect(async () => {
-    if (!props.show || !props.embedId) return
-
-    setLoading(true)
-    let doc: RequestDocEmbed | undefined
-    try {
-      doc = await embedApi.cache.getDoc(props.embedId)
-    } finally {
-      setLoading(false)
-    }
-
-    if (doc) {
-      // get the content of the document by combining all the lines
-      const lines = doc.documents.map((d) => d.msg).join('\n')
-      setContent(lines)
-    } else {
-      toastStore.error(`Failed to load embedding ${props.embedId}`)
-      props.close()
-    }
-  })
-
-  const cancel = () => {
-    setContent('')
-    props.close()
-  }
-
-  const updateEmbed = async () => {
-    if (!form || !props.embedId) return
-
-    setLoading(true)
-    try {
-      const { embedText } = getStrictForm(form, { embedText: 'string' })
-      if (!embedText) {
-        toastStore.warn(`Embedding content cannot be empty`)
-        return
-      }
-
-      await embedApi.embedPlainText(props.embedId, embedText)
-      toastStore.success('Successfully updated embedding')
-      cancel()
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const Footer = (
-    <>
-      <Button onClick={cancel}>
-        <X /> Cancel
-      </Button>
-      <Button onClick={updateEmbed}>
-        <Edit /> Update
-      </Button>
-    </>
-  )
-
-  return (
-    <Modal show={props.show} close={props.close} title="Edit Embedding" footer={Footer}>
-      <form ref={form}>
-        <TextInput
-          fieldName="embedText"
-          label="Content"
-          helperText="The content to be embedded. Use line breaks to seperate lines."
-          isMultiline
-          value={content()}
-          required
-          disabled={loading()}
-        />
-      </form>
-    </Modal>
   )
 }
 

--- a/web/pages/Memory/Memory.tsx
+++ b/web/pages/Memory/Memory.tsx
@@ -90,16 +90,25 @@ const EditEmbedModal: Component<{ show: boolean; embedId?: string; close: () => 
     }
   })
 
+  const cancel = () => {
+    setContent('')
+    props.close()
+  }
+
   const updateEmbed = async () => {
     if (!form || !props.embedId) return
 
     setLoading(true)
     try {
       const { embedText } = getStrictForm(form, { embedText: 'string' })
+      if (!embedText) {
+        toastStore.warn(`Embedding content cannot be empty`)
+        return
+      }
 
       await embedApi.embedPlainText(props.embedId, embedText)
       toastStore.success('Successfully updated embedding')
-      props.close()
+      cancel()
     } finally {
       setLoading(false)
     }
@@ -107,7 +116,7 @@ const EditEmbedModal: Component<{ show: boolean; embedId?: string; close: () => 
 
   const Footer = (
     <>
-      <Button onClick={props.close}>
+      <Button onClick={cancel}>
         <X /> Cancel
       </Button>
       <Button onClick={updateEmbed}>

--- a/web/shared/EditEmbedModal.tsx
+++ b/web/shared/EditEmbedModal.tsx
@@ -73,7 +73,13 @@ export const EditEmbedModal: Component<{ show: boolean; embedId?: string; close:
   )
 
   return (
-    <Modal show={props.show} close={props.close} title="Edit Embedding" footer={Footer}>
+    <Modal
+      show={props.show}
+      close={props.close}
+      title="Edit Embedding"
+      footer={Footer}
+      maxWidth="half"
+    >
       <form ref={form}>
         <TextInput
           fieldName="embedText"

--- a/web/shared/EditEmbedModal.tsx
+++ b/web/shared/EditEmbedModal.tsx
@@ -1,0 +1,90 @@
+import { Component, createEffect, createSignal } from 'solid-js'
+import { RequestDocEmbed } from '/web/store/embeddings/types'
+import { embedApi } from '/web/store/embeddings'
+import { toastStore } from '/web/store'
+import { getStrictForm } from '/web/shared/util'
+import Button from '/web/shared/Button'
+import { Edit, X } from 'lucide-solid'
+import Modal from '/web/shared/Modal'
+import TextInput from '/web/shared/TextInput'
+
+export const EditEmbedModal: Component<{ show: boolean; embedId?: string; close: () => void }> = (
+  props
+) => {
+  let form: HTMLFormElement | undefined
+
+  const [content, setContent] = createSignal<string>()
+  const [loading, setLoading] = createSignal(false)
+
+  createEffect(async () => {
+    if (!props.show || !props.embedId) return
+
+    setLoading(true)
+    let doc: RequestDocEmbed | undefined
+    try {
+      doc = await embedApi.cache.getDoc(props.embedId)
+    } finally {
+      setLoading(false)
+    }
+
+    if (doc) {
+      // get the content of the document by combining all the lines
+      const lines = doc.documents.map((d) => d.msg).join('\n')
+      setContent(lines)
+    } else {
+      toastStore.error(`Failed to load embedding ${props.embedId}`)
+      props.close()
+    }
+  })
+
+  const cancel = () => {
+    setContent('')
+    props.close()
+  }
+
+  const updateEmbed = async () => {
+    if (!form || !props.embedId) return
+
+    setLoading(true)
+    try {
+      const { embedText } = getStrictForm(form, { embedText: 'string' })
+      if (!embedText) {
+        toastStore.warn(`Embedding content cannot be empty`)
+        return
+      }
+
+      await embedApi.embedPlainText(props.embedId, embedText)
+      toastStore.success('Successfully updated embedding')
+      cancel()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const Footer = (
+    <>
+      <Button onClick={cancel}>
+        <X /> Cancel
+      </Button>
+      <Button onClick={updateEmbed}>
+        <Edit /> Update
+      </Button>
+    </>
+  )
+
+  return (
+    <Modal show={props.show} close={props.close} title="Edit Embedding" footer={Footer}>
+      <form ref={form}>
+        <TextInput
+          fieldName="embedText"
+          label="Content"
+          helperText="The content to be embedded. Use line breaks to seperate lines."
+          isMultiline
+          value={content()}
+          required
+          disabled={loading()}
+        />
+      </form>
+    </Modal>
+  )
+}


### PR DESCRIPTION
Adds basic functionality for editing of user embeds. Also makes embeddings page to look more like other pages in the library section.

### Styling
<details><summary>New look for embeddings list</summary>
<p>
Mostly focuses on making a card look like list items in other categories, additionally it shows an indicator for which embeds are loaded. (Currently it's not possible to force loading from here, but editing and saving an embed loads it naturally).


![image](https://github.com/agnaistic/agnai/assets/4258136/d5bc7891-63e2-4037-8790-a7a3baf5a2de)


</p>
</details> 

### Editing functionality

After an external resource has been loaded to the local cache, the contents are converted to plain text. That means there is nothing stopping us from editing it like any plain text given that the link between the source and the content is erased on embedding.

<details><summary>Example of editing a wiki article embedding</summary>
<p>

![image](https://github.com/agnaistic/agnai/assets/4258136/1a663584-e15f-40a1-8dbf-ac17fb796a56)


</p>
</details> 

**Possible future steps:**
* ~~Interface to edit embeds from the chat page~~ done in this PR
* Allow multiple embeds to be loaded in one chat