### PR TITLE
fix: better "generate more" functionality

### DIFF
--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -422,10 +422,6 @@ export async function buildPromptParts(
 
   const post = createPostPrompt(opts)
 
-  if (opts.continue) {
-    post.unshift(`${char.name}: ${opts.continue}`)
-  }
-
   const linesForMemory = [...lines].reverse()
   const books: AppSchema.MemoryBook[] = []
   if (replyAs.characterBook) books.push(replyAs.characterBook)
@@ -514,7 +510,7 @@ function createPostPrompt(
 
   if (opts.kind === 'chat-query') {
     post.push(`Query Response:`)
-  } else {
+  } else if (opts.kind !== 'continue') {
     post.push(`${opts.replyAs.name}:`)
   }
 

--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -510,7 +510,7 @@ function createPostPrompt(
 
   if (opts.kind === 'chat-query') {
     post.push(`Query Response:`)
-  } else if (opts.kind !== 'continue') {
+  } else {
     post.push(`${opts.replyAs.name}:`)
   }
 

--- a/common/template-parser.ts
+++ b/common/template-parser.ts
@@ -139,6 +139,18 @@ export async function parseTemplate(
   }
 
   const ast = parser.parse(template, {}) as PNode[]
+
+  // hack: when we continue, remove the post along with the last newline from tree
+  if (opts.continue && ast.length > 1) {
+    const last = ast[ast.length - 1]
+    if (typeof last !== 'string' && last.kind === 'placeholder' && last.value === 'post') {
+      ast.pop()
+    }
+    if (ast[ast.length - 1] === '\n') {
+      ast.pop()
+    }
+  }
+
   readInserts(opts, ast)
   let output = render(template, opts, ast)
   let unusedTokens = 0

--- a/common/template-parser.ts
+++ b/common/template-parser.ts
@@ -153,7 +153,7 @@ export async function parseTemplate(
           (node.kind === 'each' && node.value === 'history'))
     )
     if (historyIndex !== -1) {
-      const node = ast[historyIndex] as PlaceHolder | IteratorNode;
+      const node = ast[historyIndex] as PlaceHolder | IteratorNode
       // replace iterator with normalized history
       if (node.kind === 'each' && node.value === 'history') {
         ast[historyIndex] = { kind: 'placeholder', value: 'history' } as PlaceHolder

--- a/common/template-parser.ts
+++ b/common/template-parser.ts
@@ -153,6 +153,11 @@ export async function parseTemplate(
           (node.kind === 'each' && node.value === 'history'))
     )
     if (historyIndex !== -1) {
+      const node = ast[historyIndex] as PlaceHolder | IteratorNode;
+      // replace iterator with normalized history
+      if (node.kind === 'each' && node.value === 'history') {
+        ast[historyIndex] = { kind: 'placeholder', value: 'history' } as PlaceHolder
+      }
       ast = ast.slice(0, historyIndex + 1)
     }
   }
@@ -453,7 +458,7 @@ function renderIterator(holder: IterableHolder, children: CNode[], opts: Templat
   let i = 0
   for (const entity of entities) {
     let curr = ''
-    children_loop: for (const child of children) {
+    for (const child of children) {
       if (typeof child === 'string') {
         curr += child
         continue
@@ -479,8 +484,6 @@ function renderIterator(holder: IterableHolder, children: CNode[], opts: Templat
         case 'history-prop': {
           const result = renderProp(child, opts, entity, i)
           if (result) curr += result
-          // when continuing, cut the first node (last response) to its message
-          if (opts.continue && i === 0 && isHistory && child.prop === 'message') break children_loop
           break
         }
 
@@ -490,8 +493,6 @@ function renderIterator(holder: IterableHolder, children: CNode[], opts: Templat
           if (!prop) break
           const result = renderEntityCondition(child.children, opts, entity, i)
           curr += result
-          // when continuing, cut the first node (last response) to its message
-          if (opts.continue && i === 0 && isHistory) break children_loop
           break
         }
       }

--- a/common/util.ts
+++ b/common/util.ts
@@ -176,12 +176,12 @@ export function trimSentence(text: string) {
 }
 
 export function concatenateSentence(text: string, next: string) {
-  if (!text || !next) return text + next
-  if (text.endsWith('\n') || next.startsWith('\n')) {
+  if (!text || !next) return `${text}${next}`
+  if (next.startsWith('\n')) {
     return `${text.trimEnd()}\n${next.trimStart()}`
   }
 
-  return `${text.trimEnd()} ${next.trimStart()}`
+  return `${text.trimEnd()}${next}`
 }
 
 export function slugify(str: string) {

--- a/common/util.ts
+++ b/common/util.ts
@@ -175,6 +175,15 @@ export function trimSentence(text: string) {
   return index === -1 ? text.trimEnd() : text.slice(0, index + 1).trimEnd()
 }
 
+export function concatenateSentence(text: string, next: string) {
+  if (!text || !next) return text + next
+  if (text.endsWith('\n') || next.startsWith('\n')) {
+    return `${text.trimEnd()}\n${next.trimStart()}`
+  }
+
+  return `${text.trimEnd()} ${next.trimStart()}`
+}
+
 export function slugify(str: string) {
   return str
     .toLowerCase()

--- a/srv/api/chat/message.ts
+++ b/srv/api/chat/message.ts
@@ -9,6 +9,7 @@ import { v4 } from 'uuid'
 import { Response } from 'express'
 import { publishMany } from '../ws/handle'
 import { getScenarioEventType } from '/common/scenario'
+import { concatenateSentence } from '/common/util'
 
 type GenRequest = UnwrapBody<typeof genValidator>
 
@@ -271,7 +272,7 @@ export const generateMessageV2 = handle(async (req, res) => {
       }
 
       if ('partial' in gen) {
-        const prefix = body.kind === 'continue' ? `${body.continuing.msg}` : ''
+        const prefix = body.kind === 'continue' ? `${body.continuing.msg} ` : ''
         sendMany(members, {
           type: 'message-partial',
           kind: body.kind,
@@ -331,7 +332,9 @@ export const generateMessageV2 = handle(async (req, res) => {
     return
   }
 
-  const responseText = body.kind === 'continue' ? `${body.continuing.msg}${generated}` : generated
+  const responseText =
+    body.kind === 'continue' ? concatenateSentence(body.continuing.msg, generated) : generated
+
   const actions: AppSchema.ChatAction[] = []
 
   switch (body.kind) {
@@ -568,7 +571,8 @@ async function handleGuestGenerate(body: GenRequest, req: AppRequest, res: Respo
 
   if (error) return
 
-  const responseText = body.kind === 'continue' ? `${body.continuing.msg}${generated}` : generated
+  const responseText =
+    body.kind === 'continue' ? concatenateSentence(body.continuing.msg, generated) : generated
 
   const characterId = body.kind === 'self' ? undefined : body.replyAs?._id || body.char?._id
   const senderId = body.kind === 'self' ? 'anon' : undefined

--- a/srv/api/chat/message.ts
+++ b/srv/api/chat/message.ts
@@ -271,7 +271,7 @@ export const generateMessageV2 = handle(async (req, res) => {
       }
 
       if ('partial' in gen) {
-        const prefix = body.kind === 'continue' ? `${body.continuing.msg} ` : ''
+        const prefix = body.kind === 'continue' ? `${body.continuing.msg}` : ''
         sendMany(members, {
           type: 'message-partial',
           kind: body.kind,
@@ -331,7 +331,7 @@ export const generateMessageV2 = handle(async (req, res) => {
     return
   }
 
-  const responseText = body.kind === 'continue' ? `${body.continuing.msg} ${generated}` : generated
+  const responseText = body.kind === 'continue' ? `${body.continuing.msg}${generated}` : generated
   const actions: AppSchema.ChatAction[] = []
 
   switch (body.kind) {
@@ -568,7 +568,7 @@ async function handleGuestGenerate(body: GenRequest, req: AppRequest, res: Respo
 
   if (error) return
 
-  const responseText = body.kind === 'continue' ? `${body.continuing.msg} ${generated}` : generated
+  const responseText = body.kind === 'continue' ? `${body.continuing.msg}${generated}` : generated
 
   const characterId = body.kind === 'self' ? undefined : body.replyAs?._id || body.char?._id
   const senderId = body.kind === 'self' ? 'anon' : undefined

--- a/tests/__snapshots__/prompt.spec.js.snap
+++ b/tests/__snapshots__/prompt.spec.js.snap
@@ -32,7 +32,6 @@ How MainChar speaks: SAMPLECHAT MainChar
 
 <START>
 MainChar: FIRST
-MainChar: ORIGINAL
 MainChar:"
 `;
 
@@ -99,7 +98,6 @@ Scenario: MAIN MainChar
 This is how OtherBot should talk: SAMPLECHAT OtherBot
 MainChar: FIRST
 ChatOwner: SECOND
-MainChar: ORIGINAL
 OtherBot:"
 `;
 
@@ -165,7 +163,6 @@ SAMPLECHAT OtherBot
 System: New conversation started. Previous conversations are examples only.
 MainChar: FIRST
 ChatOwner: SECOND
-MainChar: ORIGINAL
 OtherBot:"
 `;
 


### PR DESCRIPTION
**Reasoning:**
Empirically, continuation of the already generated text is more consistent when the latest message is supplied as is. ~~With that in mind in this PR we remove `{{post}}` from template when request is passed with kind `continue`.~~

**Update**
Our goal here is not to manipulate `{{post}}` per se but to cut the prompt as close to the last response in history as possible to let the model continue the generation.

**New algorithm:**
1. Manipulate ast so that the history is the last node (if present)
2. When rendering complex nodes (conditionals, iterables) cut strictly after the message was rendered

That means that stuff like `ujb` and whatever was written in validated/unvalidated presets after history (like modifiers) will be erased and it can affect the generation results. However, I have tested with different prompt formats (albeit with sub 1 temperatures) and this approach beats the state of art every time.

**Known issues:**
Currently the concatenation of the existing message and the newly generated response will insert either white space or a new line between the chunks (which expands the existing behavior that always inserts a space). In case where the existing message chunk cuts off mid-word this will cause a white space inserted in the middle of a word. However, the chances of that are small enough comparing to the potential workload to factor this case in, so we ignore it for now. 

**Additional information**
Closes: #869 
[Discord thread](https://discord.com/channels/1075959979942625291/1226223451627589672)