### PR TITLE
fix: don't trim complete html tags

### DIFF
--- a/common/util.ts
+++ b/common/util.ts
@@ -131,7 +131,7 @@ export function neat(params: TemplateStringsArray, ...rest: string[]) {
     .trim()
 }
 
-const END_SYMBOLS = new Set(`."”;’'*!！?？)}]\``.split(''))
+const END_SYMBOLS = new Set(`."”;’'*!！?？)}]\`>`.split(''))
 const MID_SYMBOLS = new Set(`.)}’'!?\``.split(''))
 
 export function trimSentence(text: string) {
@@ -140,7 +140,7 @@ export function trimSentence(text: string) {
   for (let i = text.length - 1; i >= 0; i--) {
     if (END_SYMBOLS.has(text[i])) {
       // Skip ahead if the punctuation mark is preceded by white space
-      if (i && /[\p{White_Space}\n]/u.test(text[i - 1])) {
+      if (i && /[\p{White_Space}\n<]/u.test(text[i - 1])) {
         index = i - 1
         continue
       }

--- a/common/util.ts
+++ b/common/util.ts
@@ -131,7 +131,7 @@ export function neat(params: TemplateStringsArray, ...rest: string[]) {
     .trim()
 }
 
-const END_SYMBOLS = new Set(`."”;’'*!！?？)}]\`>`.split(''))
+const END_SYMBOLS = new Set(`."”;’'*!！?？)}]\`>~`.split(''))
 const MID_SYMBOLS = new Set(`.)}’'!?\``.split(''))
 
 export function trimSentence(text: string) {

--- a/tests/trim-sentence.spec.ts
+++ b/tests/trim-sentence.spec.ts
@@ -69,4 +69,41 @@ describe('trimSentence', () => {
     const result = trimSentence(text)
     expect(result).to.eq(`*Hello world.*`)
   })
+
+  it('should stop at HTML tags', () => {
+    const text = `Hello world. <div>Hello</div> World`
+    const result = trimSentence(text)
+    expect(result).to.eq(`Hello world. <div>Hello</div>`)
+  })
+
+  it('should stop at self-closing HTML tags', () => {
+    const text = `Hello world.\n<img src="" />`
+    const result = trimSentence(text)
+    expect(result).to.eq(`Hello world.\n<img src="" />`)
+  })
+
+  /* In this case we let the browser fix the markup for us */
+  it('should stop and opening HTML tags', () => {
+    const text = `Hello world. <div>Hello`
+    const result = trimSentence(text)
+    expect(result).to.eq(`Hello world. <div>`)
+  })
+
+  it('should trim math operands', () => {
+    const text = `Hello world. 2 / 2 > 2`
+    const result = trimSentence(text)
+    expect(result).to.eq(`Hello world.`)
+  })
+
+  it('should stop at HTML comments', () => {
+    const text = `Hello world.\n<!-- My HTML Comment -->`
+    const result = trimSentence(text)
+    expect(result).to.eq(`Hello world.\n<!-- My HTML Comment -->`)
+  })
+
+  it('should trim incomplete HTML comments', () => {
+    const text = `Hello world.\n<!-- My HTML Comment`
+    const result = trimSentence(text)
+    expect(result).to.eq(`Hello world.`)
+  })
 })


### PR DESCRIPTION
**UPDATE**
Added `~` to end symbols. [Relevant Discord thread](https://discord.com/channels/1075959979942625291/1230577549818466325)

***

Fixes the handling of HTML tags (not perfectly).

**Why?**
Initially I avoided putting `>` in "end symbols" because detecting the opening and closing tags is hard to do and there is always a chance to leave the markup broken in case of nested tags. However this approach results in trimming complete blocks of generated text wrapped by tags if there is no punctuation inside which is not ideal. Additionally, when parsing HTML comments it would stop at the opening tag trimming `<!--` to `<!` which is downright bad.

**Current approach**
Here we stop at closing tag symbol `>` regardless of whether it is a closing, opening or self-closing tag. Experiments show that browsers can close orphaned tags for us fixing the markup which allows us to cover most common cases with an additional provision for skipping `<` preceding end symbols to cover the case of opening HTML comment `<!--`.

**Known issues**
Since there are no special provisions for the closing symbol, 'greater than' sign can be mistaken for it if spacing is not present in the sentence. We believe this case is too rare to increase complexity of the function for it.

```javascript
const text = '2 > 1' // trims correctly
const text = '2> 1' // stops at > mistaking it for a HTML tag
```