### PR TITLE
feat(trim sentences): add multi symbol sequences

### DIFF
--- a/common/util.ts
+++ b/common/util.ts
@@ -135,12 +135,34 @@ export function neat(params: TemplateStringsArray, ...rest: string[]) {
 }
 
 const END_SYMBOLS = new Set(`."”;’'*!！?？)}]\`>~`.split(''))
+const END_SEQUENCES = [
+  '\n```',
+  '\n---',
+  '\n***',
+  '\n___',
+  '\n===',
+  '\n"""',
+]
 const MID_SYMBOLS = new Set(`.)}’'!?\``.split(''))
 
 export function trimSentence(text: string) {
   let index = -1,
     checkpoint = -1
-  for (let i = text.length - 1; i >= 0; i--) {
+  sentence_loop: for (let i = text.length - 1; i >= 0; i--) {
+    // first check for end sequences
+    for (const seq of END_SEQUENCES) {
+      if (text.slice(i, i + seq.length) === seq) {
+        // only trim if it's not an opening sequence
+        if (
+          i + seq.length < text.length &&
+          /\p{L}/u.test(text[i + seq.length])
+        ) {
+          break;
+        }
+        index = i + seq.length - 1
+        break sentence_loop
+      }
+    }
     if (END_SYMBOLS.has(text[i])) {
       // Skip ahead if the punctuation mark is preceded by white space
       if (i && /[\p{White_Space}\n<]/u.test(text[i - 1])) {

--- a/common/util.ts
+++ b/common/util.ts
@@ -135,7 +135,7 @@ export function neat(params: TemplateStringsArray, ...rest: string[]) {
 }
 
 const END_SYMBOLS = new Set(`."”;’'*!！?？)}]\`>~`.split(''))
-const END_SEQUENCES = ['\n```', '\n---', '\n***', '\n___', '\n===', '\n"""']
+const END_SEQUENCES = ['\n```', '\n---', '\n***', '\n___', '\n===', '\n"""', '\n*/']
 const MID_SYMBOLS = new Set(`.)}’'!?\``.split(''))
 
 export function trimSentence(text: string) {

--- a/common/util.ts
+++ b/common/util.ts
@@ -135,14 +135,7 @@ export function neat(params: TemplateStringsArray, ...rest: string[]) {
 }
 
 const END_SYMBOLS = new Set(`."”;’'*!！?？)}]\`>~`.split(''))
-const END_SEQUENCES = [
-  '\n```',
-  '\n---',
-  '\n***',
-  '\n___',
-  '\n===',
-  '\n"""',
-]
+const END_SEQUENCES = ['\n```', '\n---', '\n***', '\n___', '\n===', '\n"""']
 const MID_SYMBOLS = new Set(`.)}’'!?\``.split(''))
 
 export function trimSentence(text: string) {
@@ -153,11 +146,8 @@ export function trimSentence(text: string) {
     for (const seq of END_SEQUENCES) {
       if (text.slice(i, i + seq.length) === seq) {
         // only trim if it's not an opening sequence
-        if (
-          i + seq.length < text.length &&
-          /\p{L}/u.test(text[i + seq.length])
-        ) {
-          break;
+        if (i + seq.length < text.length && /\p{L}/u.test(text[i + seq.length])) {
+          break
         }
         index = i + seq.length - 1
         break sentence_loop

--- a/tests/trim-sentence.spec.ts
+++ b/tests/trim-sentence.spec.ts
@@ -106,4 +106,22 @@ describe('trimSentence', () => {
     const result = trimSentence(text)
     expect(result).to.eq(`Hello world.`)
   })
+
+  it('should stop at multi-symbol sequences', () => {
+    const text = '```javascript\nconst x = 1\n```\nMy code'
+    const result = trimSentence(text)
+    expect(result).to.eq('```javascript\nconst x = 1\n```')
+  })
+
+  it('should trim opening multi-symbol sequences that are followed by letters', () => {
+    const text = 'Beginning of my code block.\n```javascript'
+    const result = trimSentence(text)
+    expect(result).to.eq('Beginning of my code block.')
+  })
+
+  it('should trim duplicating symbols in multi-symbol sequences', () => {
+    const text = 'Hello World.\n------- Separated orphan'
+    const result = trimSentence(text)
+    expect(result).to.eq('Hello World.\n---')
+  })
 })


### PR DESCRIPTION
Adds special handling to sequences that should not be trimmed, e.g. code block closing tag, markdown separator, etc.

Side note: technically `END_SYMBOLS` could be refactored into `END_SEQUENCES` but it makes the function recursive and hurts performance, so we opted out of doing that.