### PR TITLE
feat: discard individual swipes

### DIFF
--- a/srv/api/chat/message.ts
+++ b/srv/api/chat/message.ts
@@ -392,17 +392,18 @@ export const generateMessageV2 = handle(async (req, res) => {
 
     case 'retry': {
       if (body.replacing) {
+        const nextRetries = [body.replacing.msg]
+          .concat(retries)
+          .concat(body.replacing.retries || [])
+
         await store.msgs.editMessage(body.replacing._id, {
           msg: responseText,
           actions,
           adapter,
           meta,
           state: 'retried',
-          retries: body.replacing.retries,
+          retries: nextRetries,
         })
-        const nextRetries = [body.replacing.msg]
-          .concat(retries)
-          .concat(body.replacing.retries || [])
         sendMany(members, {
           type: 'message-retry',
           requestId,

--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -279,7 +279,7 @@ const ChatDetail: Component = () => {
 
   const discardSwipe = (msgId: string, index: number) => {
     msgStore.discardSwipe(msgId, index, () => {
-      setSwipe(index - 1)
+      setSwipe(Math.max(index - 1, 0))
     })
   }
 

--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -277,6 +277,12 @@ const ChatDetail: Component = () => {
     })
   }
 
+  const discardSwipe = (msgId: string, index: number) => {
+    msgStore.discardSwipe(msgId, index, () => {
+      setSwipe(index - 1)
+    })
+  }
+
   const indexOfLastRPMessage = createMemo(() => {
     const msgs = chatMsgs()
 
@@ -436,6 +442,7 @@ const ChatDetail: Component = () => {
                     }
                     confirmSwipe={() => confirmSwipe(msg()._id)}
                     cancelSwipe={cancelSwipe}
+                    discardSwipe={() => discardSwipe(msg()._id, swipe())}
                     tts={tts()}
                     retrying={msgs.retrying}
                     partial={msgs.partial}

--- a/web/pages/Chat/DeleteMsgModal.tsx
+++ b/web/pages/Chat/DeleteMsgModal.tsx
@@ -33,6 +33,11 @@ const DeleteMsgModal: Component<{ messageId: string; show: boolean; close: () =>
           <Button schema="secondary" onClick={props.close}>
             Cancel
           </Button>
+          <Show when={!!state.msg?.retries?.length}>
+            <Button onClick={() => msgStore.discardSwipe(props.messageId, 0, props.close)}>
+              Delete Swipe
+            </Button>
+          </Show>
           <Show when={count() > 1 && state.msg?.adapter !== 'image'}>
             <Button onClick={() => confirm(true)}>Delete One</Button>
           </Show>

--- a/web/pages/Chat/components/Message.tsx
+++ b/web/pages/Chat/components/Message.tsx
@@ -73,6 +73,7 @@ type MessageProps = {
 const anonNames = new Map<string, number>()
 
 let anonId = 0
+
 function getAnonName(entityId: string) {
   if (!anonNames.has(entityId)) {
     anonNames.set(entityId, ++anonId)
@@ -398,7 +399,7 @@ const Message: Component<MessageProps> = (props) => {
               </Switch>
             </div>
           </div>
-          {props.last && props.children}
+          <Show when={!edit()}>{props.last && props.children}</Show>
         </div>
       </div>
     </div>

--- a/web/pages/Chat/components/Message.tsx
+++ b/web/pages/Chat/components/Message.tsx
@@ -11,6 +11,7 @@ import {
   Repeat1,
   Terminal,
   Trash,
+  Delete,
   X,
   Zap,
 } from 'lucide-solid'
@@ -56,6 +57,7 @@ type MessageProps = {
   swipe?: string | false
   confirmSwipe?: () => void
   cancelSwipe?: () => void
+  discardSwipe?: () => void
   onRemove: () => void
   editing: boolean
   tts?: boolean
@@ -298,12 +300,27 @@ const Message: Component<MessageProps> = (props) => {
 
                 <Match when={props.last && props.swipe}>
                   <div class="mr-4 flex items-center gap-4 text-sm">
-                    <X size={22} class="cursor-pointer text-red-500" onClick={props.cancelSwipe} />
-                    <Check
-                      size={22}
-                      class="cursor-pointer text-green-500"
+                    <div
+                      class="icon-button text-red-500"
+                      onClick={props.discardSwipe}
+                      title="Discard"
+                    >
+                      <Delete size={22} />
+                    </div>
+                    <div
+                      class="icon-button text-red-500"
+                      onClick={props.cancelSwipe}
+                      title="Cancel"
+                    >
+                      <X size={22} />
+                    </div>
+                    <div
+                      class="icon-button text-green-500"
                       onClick={props.confirmSwipe}
-                    />
+                      title="Select"
+                    >
+                      <Check size={22} />
+                    </div>
                   </div>
                 </Match>
               </Switch>

--- a/web/store/data/messages.ts
+++ b/web/store/data/messages.ts
@@ -124,8 +124,8 @@ export async function guidance<T = any>(
   return res.result!.values
 }
 
-export async function swapMessage(msg: AppSchema.ChatMessage, _msg: string, _retries: string[]) {
-  return swapMessageProps(msg, { msg: _msg, retries: _retries })
+export async function swapMessage(msg: AppSchema.ChatMessage, text: string, retries: string[]) {
+  return swapMessageProps(msg, { msg: text, retries })
 }
 
 export async function swapMessageProps(


### PR DESCRIPTION
Adds ability to permanently remove messages from `retries` array, aka discard swipes.
![image](https://github.com/agnaistic/agnai/assets/4258136/be012a95-51d5-45bf-8979-42905103dd44)

Additionally, it brings the styling of these buttons to be the same as editing buttons (divs instead of just icons) and adds titles to them for clarity.

This PR also addresses a UX issue, where during the editing of a message it was possible to cycle through swipes messing up the message state. Now during the edit the swipe controls are hidden.

**Additional Information**: [Relevant Discord thread](https://discord.com/channels/1075959979942625291/1226163668387889243)