### PR TITLE
feat: add hotkey to edit last message

### DIFF
--- a/web/pages/Chat/components/InputBar.tsx
+++ b/web/pages/Chat/components/InputBar.tsx
@@ -280,6 +280,22 @@ const InputBar: Component<{
             ev.preventDefault()
           }
         }}
+        onKeyUp={(ev) => {
+          if (ev.key === 'ArrowUp') {
+            const editBtn = document.querySelector(
+              '[data-last="true"] .edit-btn'
+            ) as HTMLDivElement | null
+            if (!editBtn) return
+
+            editBtn.click()
+            const msgBox = document.querySelector(
+              '[data-last="true"] .msg-edit-text-box'
+            ) as HTMLDivElement | null
+            if (!msgBox) return
+
+            msgBox.focus()
+          }
+        }}
         onInput={updateText}
       />
       <Button schema="clear" onClick={onButtonClick} class="h-full px-2 py-2">


### PR DESCRIPTION
Adds a hotkey (arrow up) to edit the last message in the chat, a functionality present in most chat applications. This closes the ux loop: send message -> edit response -> apply changes -> send new message, allowing to complete it with keyboard only.

**Implementation note**
After some deliberation I worked around solidjs in a simple 10 lines js handler. The only viable alternative I see for this to be implemented the "right way" is to introduce a new field to the Message Store which seemed excessive for such a trivial thing.