### PR TITLE
fix: add max-height to input bar

### DIFF
--- a/web/app.css
+++ b/web/app.css
@@ -82,3 +82,8 @@
     transform: rotate(360deg);
   }
 }
+
+.input-bar {
+  max-height: 50vh;
+  max-height: 50svh;
+}


### PR DESCRIPTION
Makes it so the input bar in a chat cannot grow larger than half the screen size which can be problematic on mobile devices.

<details><summary>Screenshot</summary>
<p>

![image](https://github.com/agnaistic/agnai/assets/4258136/a3680b5f-f707-452f-8cf6-7b41644881cb)


</p>
</details> 