### PR TITLE
fix: add prompt order to agnaistic preset

### DIFF
--- a/common/presets/agnaistic.ts
+++ b/common/presets/agnaistic.ts
@@ -35,5 +35,43 @@ export const agnaiPresets = {
     antiBond: false,
     useAdvancedPrompt: 'basic',
     promptOrderFormat: 'Alpaca',
+    promptOrder: [
+      {
+        placeholder: 'system_prompt',
+        enabled: true,
+      },
+      {
+        placeholder: 'scenario',
+        enabled: true,
+      },
+      {
+        placeholder: 'personality',
+        enabled: true,
+      },
+      {
+        placeholder: 'impersonating',
+        enabled: true,
+      },
+      {
+        placeholder: 'chat_embed',
+        enabled: true,
+      },
+      {
+        placeholder: 'memory',
+        enabled: true,
+      },
+      {
+        placeholder: 'example_dialogue',
+        enabled: true,
+      },
+      {
+        placeholder: 'history',
+        enabled: true,
+      },
+      {
+        placeholder: 'ujb',
+        enabled: true,
+      },
+    ],
   },
 } satisfies Record<string, Partial<AppSchema.GenSettings>>


### PR DESCRIPTION
Without a `promptOrder` present `basic` prompt doesn't work and agnaistic preset falls back to a default template. This is the source of complaints that `impersonation` doesn't appear in prompt with default settings.

**QA Instructions**
It needs testing because I can't test it locally properly.