### PR TITLE
fix: calculate index of last message

### DIFF
--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -278,10 +278,16 @@ const ChatDetail: Component = () => {
   }
 
   const indexOfLastRPMessage = createMemo(() => {
-    return msgs.msgs.reduceRight(
-      (prev, curr, i) => (prev > -1 ? prev : !curr.ooc && curr.adapter !== 'image' ? i : -1),
-      -1
-    )
+    let index = -1
+    for (let i = chatMsgs().length - 1; i >= 0; i--) {
+      const curr = chatMsgs()[i]
+      if (!curr.ooc && curr.adapter !== 'image') {
+        index = i
+        break
+      }
+    }
+
+    return index
   })
 
   const generateFirst = () => {

--- a/web/pages/Chat/ChatDetail.tsx
+++ b/web/pages/Chat/ChatDetail.tsx
@@ -278,16 +278,16 @@ const ChatDetail: Component = () => {
   }
 
   const indexOfLastRPMessage = createMemo(() => {
-    let index = -1
-    for (let i = chatMsgs().length - 1; i >= 0; i--) {
-      const curr = chatMsgs()[i]
+    const msgs = chatMsgs()
+
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      const curr = msgs[i]
       if (!curr.ooc && curr.adapter !== 'image') {
-        index = i
-        break
+        return i
       }
     }
 
-    return index
+    return -1
   })
 
   const generateFirst = () => {


### PR DESCRIPTION
Fixed discrepancy between what messages are rendered on the page and how last message's index is calculated. The new version uses the same array (memo) and is rewritten to avoid reducing over the whole array.

Closes #931 
Closes #775 (needs testing but it should be the same problem)