### PR TITLE
Fix incorrect max token limit

### DIFF
--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -816,7 +816,12 @@ export function getContextLimit(
     }
 
     case 'openai': {
-      const limit = OPENAI_CONTEXTS[model] || 8100
+      var limit
+      if (model in OPENAI_CONTEXTS) {
+        limit = OPENAI_CONTEXTS[model]
+      } else {
+        limit = configuredMax
+      }
       return Math.min(configuredMax, limit) - genAmount
     }
 


### PR DESCRIPTION
The max token limit was incorrect when using OpenAI adapter with a custom model.