### PR TITLE
Add system block node to template parser

### DIFF
--- a/common/grammar.ts
+++ b/common/grammar.ts
@@ -25,11 +25,17 @@ Expression = content:Parent* {
     return results
 }
 
-Parent "parent-node" = v:(BotIterator / ChatEmbedIterator / HistoryIterator / HistoryInsert / LowPriority / Condition / Placeholder / Text) { return v }
+Parent "parent-node" = v:(SystemBlock / BotIterator / ChatEmbedIterator / HistoryIterator / HistoryInsert / LowPriority / Condition / Placeholder / Text) { return v }
 
 ManyPlaceholder "repeatable-placeholder" = OP i:(Character / User / Random / DiceRoll) CL {
 	return { kind: 'placeholder', value: i }
 }
+
+/** System Blocks */
+SystemBlock "system-block" = OpenSystem text:BlockText+ CloseSystem { return { kind: 'system-block', value: text.join('') } }
+OpenSystem "open-system" = "<system>"i
+CloseSystem "open-system" = "</system>"i
+BlockText "block-text" = !(CloseSystem) ch:. { return ch }
 
 BotIterator "bot-iterator" = OP "#each" WS loop:Bots CL children:(BotChild / LoopText)* CloseLoop { return { kind: 'each', value: loop, children } }
 BotChild = i:(BotRef / BotCondition / ManyPlaceholder) { return i }

--- a/common/presets/templates.ts
+++ b/common/presets/templates.ts
@@ -91,6 +91,14 @@ export const BUILTIN_FORMATS: { [key in ModelFormat]: FormatTags } = {
   },
 }
 
+export function replaceArrayTags(prompts: string[], format: FormatTags | ModelFormat) {
+  const next: string[] = []
+  for (const prompt of prompts) {
+    next.push(replaceTags(prompt, format))
+  }
+  return next
+}
+
 export function replaceTags(prompt: string, format: FormatTags | ModelFormat) {
   if (!format) {
     format = 'None'

--- a/common/prompt-order.ts
+++ b/common/prompt-order.ts
@@ -87,7 +87,7 @@ export const SIMPLE_ORDER: NonNullable<AppSchema.GenSettings['promptOrder']> = [
 
 export const formatHolders: Record<string, Record<string, string>> = {
   Universal: {
-    system_prompt: neat`<system>{{#if system_prompt}}{{value}}</system>{{#else}}${defaultSystemPrompt}</system>{{/else}}{{/if}}`,
+    system_prompt: neat`<system>{{#if system_prompt}}{{value}}{{#else}}${defaultSystemPrompt}{{/else}}{{/if}}</system>`,
     scenario: neat`{{#if scenario}}The scenario of the conversation:\n{{scenario}}\n{{/if}}`,
     memory: neat`{{#if memory}}"{{char}}'s" memories:\n{{memory}}\n{{/if}}`,
     personality: neat`{{#if personality}}{{char}}'s personality:\n{{personality}}\n{{/if}}`,

--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -9,7 +9,7 @@ import { parseTemplate } from './template-parser'
 import { getMessageAuthor, getBotName, trimSentence, neat } from './util'
 import { Memory } from './types'
 import { promptOrderToTemplate, SIMPLE_ORDER } from './prompt-order'
-import { ModelFormat, replaceTags } from './presets/templates'
+import { ModelFormat, replaceArrayTags, replaceTags } from './presets/templates'
 import { PromptTemplate } from './types/presets'
 import { isDefaultPreset } from './default-preset'
 import { OPENAI_CONTEXTS } from './presets/openai'
@@ -229,10 +229,6 @@ export async function createPromptParts(opts: PromptOpts, encoder: TokenCounter)
    */
   let template = getTemplate(opts)
 
-  if (opts.modelFormat) {
-    template = replaceTags(template, opts.modelFormat)
-  }
-
   /**
    * It's important for us to pass in a max context that is _realistic-ish_ as the embeddings
    * are retrieved based on the number of history messages we return here.
@@ -258,6 +254,10 @@ export async function createPromptParts(opts: PromptOpts, encoder: TokenCounter)
     encoder,
     jsonValues: opts.jsonValues,
   })
+
+  if (opts.modelFormat) {
+    prompt.parsed = replaceTags(prompt.parsed, opts.modelFormat)
+  }
 
   return { lines, parts, template: prompt, indexes }
 }
@@ -364,8 +364,6 @@ type InjectOpts = {
 export async function injectPlaceholders(template: string, inject: InjectOpts) {
   const { opts, parts, history: hist, encoder, ...rest } = inject
 
-  template = replaceTags(template, inject.format || opts.settings?.modelFormat || 'None')
-
   /**
    * This is currently disabled:
    * Models behave far too differently to insert sample chat using this method.
@@ -420,7 +418,20 @@ export async function injectPlaceholders(template: string, inject: InjectOpts) {
       encoder,
     },
   })
+
+  const format = inject.format || opts.settings?.modelFormat || 'None'
+  result.parsed = replaceTags(result.parsed, format)
+  result.sections.strictSystem = replaceArrayTags(result.sections.strictSystem, format)
+  replaceSectionTags(result.sections.sections, format)
+
   return result
+}
+
+function replaceSectionTags(sections: Record<string, string[] | any>, format: ModelFormat) {
+  for (const key in sections) {
+    if (!Array.isArray(sections[key])) continue
+    sections[key] = replaceArrayTags(sections[key], format)
+  }
 }
 
 /**
@@ -991,6 +1002,9 @@ export function resolveScenario(
       result += `\n${book.text}`
     }
   }
+
+  // The scenario `{{char}}` placeholders must always refer to the owner of the scenario
+  result.replace(/{{char}}/gi, mainChar.name)
 
   return result.trim()
 }

--- a/common/prompt.ts
+++ b/common/prompt.ts
@@ -486,13 +486,16 @@ export async function buildPromptPlaceholders(
   const { chat, char, replyAs } = opts
   const sender = opts.impersonate ? opts.impersonate.name : opts.sender?.handle || 'You'
 
-  const replace = (value: string) => placeholderReplace(value, opts.replyAs.name, sender)
+  const replace = (value: string, botName?: string) =>
+    placeholderReplace(value, botName || opts.replyAs.name, sender)
 
   const parts: PromptPlaceholders = {
     systemPrompt: opts.settings?.systemPrompt || '',
-    persona: formatCharacter(
-      replyAs.name,
-      replyAs._id === char._id ? chat.overrides ?? replyAs.persona : replyAs.persona
+    persona: replace(
+      formatCharacter(
+        replyAs.name,
+        replyAs._id === char._id ? chat.overrides ?? replyAs.persona : replyAs.persona
+      )
     ),
     prefill: opts.settings?.prefill || '',
     post: [],
@@ -504,10 +507,12 @@ export async function buildPromptPlaceholders(
   const personalities = new Set([replyAs._id])
 
   if (opts.impersonate?.persona) {
-    parts.impersonality = formatCharacter(
-      opts.impersonate.name,
-      opts.impersonate.persona,
-      opts.impersonate.persona.kind
+    parts.impersonality = replace(
+      formatCharacter(
+        opts.impersonate.name,
+        opts.impersonate.persona,
+        opts.impersonate.persona.kind
+      )
     )
   }
 
@@ -524,7 +529,10 @@ export async function buildPromptPlaceholders(
 
     personalities.add(bot._id)
     parts.allPersonas.push(
-      `${bot.name}'s personality: ${formatCharacter(bot.name, bot.persona, bot.persona.kind)}`
+      `${bot.name}'s personality: ${replace(
+        formatCharacter(bot.name, bot.persona, bot.persona.kind),
+        bot.name
+      )}`
     )
   }
 
@@ -541,7 +549,7 @@ export async function buildPromptPlaceholders(
     .split('\n')
     .filter(removeEmpty)
     // This will use the 'replyAs' character "if present", otherwise it'll defer to the chat.character.name
-    .map(replace)
+    .map((text) => replace(text))
 
   if (chat.greeting) {
     parts.greeting = replace(chat.greeting)
@@ -565,7 +573,7 @@ export async function buildPromptPlaceholders(
   parts.ujb = supplementary.ujb
   parts.systemPrompt = supplementary.system
 
-  parts.post = post.map(replace)
+  parts.post = post.map((post) => replace(post))
 
   if (opts.userEmbeds) {
     const embeds = opts.userEmbeds.map((line) => line.text)

--- a/common/requests/openai.ts
+++ b/common/requests/openai.ts
@@ -3,11 +3,7 @@ import { streamGenerator } from './stream'
 import { PayloadOpts } from './types'
 import { joinUrl, sanitiseAndTrim } from './util'
 import { countTokens } from '../tokenize'
-import {
-  stripImageContent,
-  toChatMessages,
-  validateChatMessages,
-} from '/srv/adapter/template-chat-payload'
+import { stripImageContent, toChatMessages } from '/srv/adapter/template-chat-payload'
 import { toImageJinjaTemplate } from './payloads'
 
 type Role = 'user' | 'assistant' | 'system'
@@ -31,7 +27,6 @@ export async function* handleOAI(opts: PayloadOpts, signal: AbortController, pay
   const options = { ...opts, gen }
 
   const { messages } = await toChatMessages(options, countTokens)
-  validateChatMessages(messages)
 
   if (gen.jinjaEnabled) {
     payload.chat_template = toImageJinjaTemplate({

--- a/common/template-parser.ts
+++ b/common/template-parser.ts
@@ -79,7 +79,16 @@ function loadParser() {
 
 const HISTORY_MARKER = '__history__marker__'
 
-type PNode = PlaceHolder | ConditionNode | IteratorNode | InsertNode | LowPriorityNode | string
+type PNode =
+  | SystemNode
+  | PlaceHolder
+  | ConditionNode
+  | IteratorNode
+  | InsertNode
+  | LowPriorityNode
+  | string
+
+type SystemNode = { kind: 'system-block'; value: string }
 
 type PlaceHolder = {
   kind: 'placeholder'
@@ -455,6 +464,12 @@ function renderNode(node: PNode, opts: TemplateOpts, flags: InternalFlags, condi
   }
 
   switch (node.kind) {
+    case 'system-block': {
+      const subAst = parser.parse(node.value)
+      const result = renderNodes(subAst, opts, flags)
+      return `<system>${result}</system>`
+    }
+
     case 'placeholder': {
       const result = getPlaceholder(node, opts, flags, conditionText)
       return result
@@ -973,6 +988,10 @@ function getMarker(opts: TemplateOpts, node: PNode, previous: Section): Section 
   }
 
   switch (node.kind) {
+    case 'system-block': {
+      return 'system'
+    }
+
     case 'placeholder': {
       if (node.value === 'history') return 'history'
       if (node.value === 'system_prompt') return 'system'

--- a/common/template-parser.ts
+++ b/common/template-parser.ts
@@ -11,7 +11,7 @@ type Section = 'pre_system' | 'system' | 'post_system' | 'history' | 'post'
 let DEBUG = false
 const SAMPLE_CHAT_LP = `__lp_sample_chat__`
 
-type InternalFlags = { sample_chat?: boolean }
+type InternalFlags = { sample_chat?: boolean; pre_render?: boolean; is_final?: boolean }
 
 export type TemplateOpts = {
   continue?: boolean
@@ -19,7 +19,6 @@ export type TemplateOpts = {
   chat: AppSchema.Chat
 
   isPart?: boolean
-  isFinal?: boolean
 
   char: AppSchema.Character
   replyAs?: AppSchema.Character
@@ -201,7 +200,7 @@ export async function parseTemplate(
     opts.limit.output = {}
   }
 
-  const flags: InternalFlags = {}
+  const flags: InternalFlags = { pre_render: true }
 
   const sections: TemplateOpts['sections'] = {
     flags: {},
@@ -230,6 +229,7 @@ export async function parseTemplate(
     opts.isPart = false
   }
 
+  flags.pre_render = false
   const ast = parser.parse(template, {}) as PNode[]
   readInserts(opts, ast, flags)
   let output = render(template, opts, flags, ast)
@@ -250,9 +250,9 @@ export async function parseTemplate(
   /**
    * Some placeholders require re-parsing as they also contain placeholders
    */
-  opts.isFinal = true
+  flags.is_final = true
   const result = render(output, opts, flags).replace(/\r\n/g, '\n').replace(/\n\n+/g, '\n\n').trim()
-  opts.isFinal = false
+  flags.is_final = false
 
   /** Replace iterators */
   let history: string[] = []
@@ -319,7 +319,7 @@ export async function parseTemplate(
     }
   }
 
-  opts.isFinal = true
+  flags.is_final = true
   output = render(output, opts, flags).replace(/\r\n/g, '\n').replace(/\n\n+/g, '\n\n').trim()
 
   if (opts.lowpriority) {
@@ -435,7 +435,7 @@ function render(template: string, opts: TemplateOpts, flags: InternalFlags, exis
       }
 
       if (!opts.sections?.done) {
-        fillSection(opts, prevMarker, result)
+        fillSection(opts, prevMarker, flags, result)
       }
 
       if (result) {
@@ -636,12 +636,9 @@ function renderCondition(
     if (result) elseOutput.push(result)
   }
 
-  const value = getPlaceholder(node, opts, flags)
-  if (!value) {
-    if (elseOutput.length) {
-      return elseOutput.join('')
-    }
-    return
+  let value = getPlaceholder(node, opts, flags)
+  if (!value && elseOutput.length) {
+    value = elseOutput.join('')
   }
 
   const output: string[] = []
@@ -799,7 +796,7 @@ function getPlaceholder(
     return `{{${node.value}}}`
   }
 
-  if (opts.isFinal && FINAL_IGNORE_HOLDERS[node.value]) {
+  if (flags.is_final && FINAL_IGNORE_HOLDERS[node.value]) {
     return `{{${node.value}}}`
   }
 
@@ -941,7 +938,13 @@ function handleDice(node: DiceExpr) {
   return rand
 }
 
-function fillSection(opts: TemplateOpts, marker: Section | undefined, result: string | undefined) {
+function fillSection(
+  opts: TemplateOpts,
+  marker: Section | undefined,
+  interal: InternalFlags,
+  result: string | undefined
+) {
+  if (interal.pre_render) return
   if (!opts.sections) return
   if (!result) return
   if (result === HISTORY_MARKER) return

--- a/common/template-parser.ts
+++ b/common/template-parser.ts
@@ -641,6 +641,9 @@ function renderCondition(
     value = elseOutput.join('')
   }
 
+  // If the condition's placeholder and else-block is empty: return nothing
+  if (!value?.trim()) return
+
   const output: string[] = []
 
   for (const child of children) {

--- a/srv/adapter/generate.ts
+++ b/srv/adapter/generate.ts
@@ -21,7 +21,7 @@ import {
 import { getCachedSubscriptionModels } from '../db/subscriptions'
 import { sendOne } from '../api/ws'
 import { ResponseSchema } from '/common/types/library'
-import { toChatMessages } from './template-chat-payload'
+import { toChatMessages, validateChatMessages } from './template-chat-payload'
 import { isDefaultPreset } from '/common/default-preset'
 import { getPresetConnection } from '/common/providers'
 
@@ -441,7 +441,7 @@ export async function createChatStream(
     log,
     members: opts.members.concat(opts.sender),
     prompt: assembled.prompt,
-    messages,
+    messages: validateChatMessages(messages),
     parts: assembled.parts,
     sender: opts.sender,
     mappedSettings,

--- a/srv/adapter/openrouter.ts
+++ b/srv/adapter/openrouter.ts
@@ -7,7 +7,7 @@ import { AppLog } from '../middleware'
 import { OpenRouterModel } from '/common/adapters'
 import { getStoppingStrings } from './prompt'
 import { createClaudeChatCompletion } from './claude'
-import { validateChatMessages, logPayload, stripImageContent } from './template-chat-payload'
+import { logPayload, stripImageContent } from './template-chat-payload'
 import { streamGenerator } from '/common/requests/stream'
 import { getJsonSchemaPayload } from '/common/guidance/json-schema'
 
@@ -79,10 +79,6 @@ export const handleOpenRouter: ModelAdapter = async function* (opts) {
     payload.messages = opts.messages
   } else {
     payload.prompt = opts.prompt
-  }
-
-  if (payload.messages) {
-    payload.messages = validateChatMessages(payload.messages)
   }
 
   yield {

--- a/srv/adapter/template-chat-payload.ts
+++ b/srv/adapter/template-chat-payload.ts
@@ -213,9 +213,9 @@ export function remapImageContent(
   return messages
 }
 
-export function validateChatMessages(messages: CompletionItem[]) {
+export function validateChatMessages(messages: Array<{ role: string; content: any }>) {
   let lastRole = ''
-  const next: CompletionItem[] = []
+  const next: typeof messages = []
 
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i]

--- a/web/pages/Admin/Config/Images.tsx
+++ b/web/pages/Admin/Config/Images.tsx
@@ -73,8 +73,8 @@ const ImageModels: Component<{ signal: Signal<Model[]> }> = (props) => {
       init: {
         steps: 20,
         cfg: 5,
-        height: 1024,
-        width: 1024,
+        height: 1216,
+        width: 1216,
         prefix: '',
         suffix: '',
         negative: '',
@@ -120,7 +120,7 @@ const Model: Component<{
   remove: (index: number) => void
 }> = (props) => {
   return (
-    <Accordian title={props.item.desc} titleClickOpen open={false}>
+    <Accordian title={props.item.desc} titleClickOpen open={!props.item.name}>
       <Card
         bg="bg-900"
         bgOpacity={1}

--- a/web/pages/Chat/components/Attachments.tsx
+++ b/web/pages/Chat/components/Attachments.tsx
@@ -33,11 +33,6 @@ export const MessageAttachments: Component<{ ctx: ContextState; msg: AppSchema.C
               onClick={() =>
                 settingStore.showImage(image, [
                   {
-                    schema: 'secondary',
-                    text: 'Close',
-                    onClick: () => settingStore.clearImage(),
-                  },
-                  {
                     schema: 'warning',
                     text: 'Remove',
                     onClick: () => {

--- a/web/pages/Chat/components/MemoryModal.tsx
+++ b/web/pages/Chat/components/MemoryModal.tsx
@@ -160,17 +160,23 @@ const ChatMemoryModal: Component<{
               Use Embedding
             </Button>
 
-            <Show when={embedId() === props.chat?.userEmbedId}>
-              <Button
-                class="w-fit"
-                schema="secondary"
-                disabled={editingEmbed() || !props.chat?.userEmbedId}
-                onClick={() => setEditingEmbed(true)}
-              >
-                <Edit size={16} />
-                Edit
-              </Button>
-            </Show>
+            <Button
+              class="w-fit"
+              disabled={editingEmbed() || !embedId()}
+              onClick={() => setEditingEmbed(true)}
+            >
+              <Edit size={16} />
+              Edit
+            </Button>
+
+            <Button
+              schema="error"
+              class="w-fit"
+              disabled={!embedId()}
+              onClick={() => embedApi.removeDocument(embedId()!)}
+            >
+              Remove
+            </Button>
           </div>
           <Portal>
             <EditEmbedModal

--- a/web/pages/Memory/EmbedContent.tsx
+++ b/web/pages/Memory/EmbedContent.tsx
@@ -178,6 +178,7 @@ const EmbedContent: Component = (props) => {
             helperText="The content to be embedded. Use line breaks to seperate lines."
             isMultiline
             onChange={(ev) => setStore('embedText', ev.currentTarget.value)}
+            class="max-h-80"
           />
 
           <Button class="mt-2 w-fit" onClick={embedFile}>

--- a/web/pages/Memory/EmbedContent.tsx
+++ b/web/pages/Memory/EmbedContent.tsx
@@ -41,6 +41,10 @@ const EmbedContent: Component = (props) => {
   }
 
   const embedFile = async () => {
+    if (!store.embedName) {
+      toastStore.error(`Enter a name for the embedding`)
+    }
+
     setLoading(true)
     try {
       const docNeeded = store.type === 'PDF' || store.type === 'Text file'

--- a/web/shared/PresetSettings/ThirdPartyModel.tsx
+++ b/web/shared/PresetSettings/ThirdPartyModel.tsx
@@ -170,23 +170,20 @@ const CompatModel: Field = (props) => {
           </Show>
         }
         label={
-          <div class="flex justify-between">
+          <div class="flex items-center gap-2">
             <div>Model</div>
-            <div class="flex gap-2">
-              <Show when={modelList().length > 1}>
-                <CustomSelect
-                  modalTitle={`Select Model: ${new URL(models.url).host || '...'}`}
-                  parentClass="flex w-full justify-end"
-                  size="sm"
-                  selected={props.state.thirdPartyModel}
-                  options={modelList()}
-                  onSelect={(ev) => onModelSelect(ev.value)}
-                  search={tokenizedSearch}
-                  buttonLabel={`Select Model`}
-                  hide={modelList().length <= 1}
-                  disabled={models.loading}
-                />
-              </Show>
+            <div class="ml-2 flex gap-2">
+              <CustomSelect
+                modalTitle={`Select Model: ${new URL(models.url).host || '...'}`}
+                parentClass="flex w-full justify-end"
+                size="sm"
+                selected={props.state.thirdPartyModel}
+                options={modelList()}
+                onSelect={(ev) => onModelSelect(ev.value)}
+                search={tokenizedSearch}
+                buttonLabel={`Select Model`}
+                disabled={models.loading || modelList().length <= 1}
+              />
 
               <Button
                 size="sm"

--- a/web/store/character.ts
+++ b/web/store/character.ts
@@ -85,66 +85,6 @@ export const characterStore = createStore<CharacterState>(
   'character',
   initState
 )((get, set) => {
-  events.on(EVENTS.loggedOut, () => {
-    characterStore.setState({ ...initState })
-    characterStore.getCharacters(true)
-  })
-
-  events.on(EVENTS.loggedIn, () => {
-    characterStore.setState({ ...initState })
-  })
-
-  events.on(EVENTS.charAdded, (char: AppSchema.Character) => {
-    const { chatChars: prev } = get()
-    set({
-      chatChars: {
-        chatId: prev.chatId,
-        list: prev.list.concat(char),
-        map: Object.assign({}, prev.map, { [char._id]: char }),
-      },
-    })
-  })
-
-  events.on(
-    EVENTS.charsReceived,
-    async (chatId: string, chars: AppSchema.Character[], temps: AppSchema.Character[]) => {
-      const allChars = chars.concat(temps)
-      set({ chatChars: { chatId, list: allChars, map: toMap(allChars) } })
-      characterStore.loadImpersonate(chatId)
-    }
-  )
-
-  events.on(EVENTS.init, (data) => {
-    if (!data.characters) return
-    events.emit(EVENTS.allChars, data.characters)
-  })
-
-  events.on(EVENTS.chatOpened, (chatId: string) => {
-    set({ activeChatId: chatId })
-  })
-
-  events.on(EVENTS.chatClosed, () => {
-    set({ activeChatId: '' })
-    characterStore.loadImpersonate()
-  })
-
-  events.on(EVENTS.allChars, async (chars: AppSchema.Character[]) => {
-    const state = get()
-    const userId = getUserId()
-
-    set({
-      characters: {
-        map: toMap(chars),
-        list: chars.filter((ch) => ch.userId === userId),
-        loaded: Date.now(),
-      },
-    })
-
-    if (state.impersonating) return
-
-    characterStore.loadImpersonate()
-  })
-
   return {
     clearCharacter() {
       return { editing: undefined }
@@ -508,6 +448,66 @@ subscribe(
     })
   }
 )
+
+events.on(EVENTS.loggedOut, () => {
+  characterStore.setState({ ...initState })
+  characterStore.getCharacters(true)
+})
+
+events.on(EVENTS.loggedIn, () => {
+  characterStore.setState({ ...initState })
+})
+
+events.on(EVENTS.charAdded, (char: AppSchema.Character) => {
+  const { chatChars: prev } = characterStore.getState()
+  characterStore.setState({
+    chatChars: {
+      chatId: prev.chatId,
+      list: prev.list.concat(char),
+      map: Object.assign({}, prev.map, { [char._id]: char }),
+    },
+  })
+})
+
+events.on(
+  EVENTS.charsReceived,
+  async (chatId: string, chars: AppSchema.Character[], temps: AppSchema.Character[]) => {
+    const allChars = chars.concat(temps)
+    characterStore.setState({ chatChars: { chatId, list: allChars, map: toMap(allChars) } })
+    characterStore.loadImpersonate(chatId)
+  }
+)
+
+events.on(EVENTS.init, (data) => {
+  if (!data.characters) return
+  events.emit(EVENTS.allChars, data.characters)
+})
+
+events.on(EVENTS.chatOpened, (chatId: string) => {
+  characterStore.setState({ activeChatId: chatId })
+})
+
+events.on(EVENTS.chatClosed, () => {
+  characterStore.setState({ activeChatId: '' })
+  characterStore.loadImpersonate()
+})
+
+events.on(EVENTS.allChars, async (chars: AppSchema.Character[]) => {
+  const state = characterStore.getState()
+  const userId = getUserId()
+
+  characterStore.setState({
+    characters: {
+      map: toMap(chars),
+      list: chars.filter((ch) => ch.userId === userId),
+      loaded: Date.now(),
+    },
+  })
+
+  if (state.impersonating) return
+
+  characterStore.loadImpersonate()
+})
 
 function replace(
   map: Record<string, AppSchema.Character>,

--- a/web/store/data/bot-generate.ts
+++ b/web/store/data/bot-generate.ts
@@ -180,7 +180,11 @@ export async function generateResponse(
 
   request.eventStream = true
 
-  console.log(`${opts.kind} cx:${!!opts.signal} p:${request.parent?.slice(0, 5) || 'none'}`)
+  console.log(
+    `${opts.kind} cx:${!!opts.signal} p:${
+      request.parent?.slice(0, 5) || 'none'
+    } rep:${request.replacing?._id?.slice(0, 4)}`
+  )
 
   api.fetchSSE({
     path: `/chat/${entities.chat._id}/generate`,

--- a/web/store/embeddings/cache.ts
+++ b/web/store/embeddings/cache.ts
@@ -84,6 +84,8 @@ async function saveDocument(id: string, doc: EmbeddedDocument) {
 
 async function deleteDocument(docId: string) {
   const ids = await getCachedIds()
+  if (!docId) return ids
+
   const nextIds = ids.filter((doc) => doc._id !== docId)
   await lf.setItem(CACHE_KEY, JSON.stringify(nextIds))
   await lf.removeItem(`${CACHE_KEY}_${docId}`)


### PR DESCRIPTION
Contents wrapped in `<system> ... </system>` will always be included in the `role: 'system'` messages.

- add new parser node: system-block
- always show model list button
- remove redundant close button