### PR TITLE
cancel CI workflow that becomes obsolete after a new commit is pushed in an open PR

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,6 +6,11 @@ permissions:
 
 on: pull_request
 
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+
 env:
   node-version: '22.14.0'
   pnpm-version: 10.6.1


### PR DESCRIPTION
### Change Summary
Currently, if a PR is open and a push happens, the **Automated checks** workflow will start running. If, shortly after a subsequent push on the *same* PR happens, the workflow will start running again without cancelling the previous (now obsolete) run. With these changes, the first run would be cancelled, thus saving compute resources (see below for quantity) without sacrificing functionality, since the second run will contain the changes from the first push as well.

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Here is an example of the behaviour described above: the commit `9ee1663` triggered [this](https://github.com/agnaistic/agnai/actions/runs/14258317073/) workflow run, and shortly after the commit `3fe0a02`, that happened on top of the first commit, triggered [this](https://github.com/agnaistic/agnai/actions/runs/14258323839/) workflow. Both workflows ran till the end, spending approximately 57 CPU seconds each. With the proposed changes, the first run would be cancelled, hence saving ~6.0 CPU seconds and clearing the queue for other workflows. Note that this is an example of a single concurrent run, and the accumulated gain for all PRs would be higher.

Kindly let us know (here or in the email below) if you would like more details, if you want to reject the proposed changes for other reasons, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch

PS: Some hyperlinks may not work if the corresponding workflows have been deleted.