### PR TITLE
bug: "Memory Book" import visual bug #1244

### DIFF
--- a/web/shared/FileInput.tsx
+++ b/web/shared/FileInput.tsx
@@ -26,8 +26,9 @@ const FileInput: Component<{
 
       const files = await Promise.all(Array.from(list).map(getFileAsDataURL))
       props.onUpdate(files)
-    } finally {
+    } catch (error) {
       inputRef.value = ''
+      throw error
     }
   }
 


### PR DESCRIPTION
fixing ["Memory Book" import visual bug #1244](https://github.com/agnaistic/agnai/issues/1244)

FileInput no longer clears the file name after file selection.